### PR TITLE
Fixes for restore function

### DIFF
--- a/lib/natural/bayes_classifier.js
+++ b/lib/natural/bayes_classifier.js
@@ -148,7 +148,7 @@ function BayesClassifier(stemmer) {
 
 BayesClassifier.functionify = functionify;
 BayesClassifier.restore = function(data, stemmer) {
-    if(data instanceof String)
+    if(typeof data === 'string')
         data = JSON.parse(data);
 
     functionify(data, stemmer);


### PR DESCRIPTION
Unfortunately I have an anal editor that trims trailing whitespace so the diff looks a bit messed up. 

The first fix fixes the variable typo.

The second fix replaces the `data instanceof String` thing which didn't work. I'm not a javascript expert by any means but I added a console log into the else statement of if and `typeof data` was a string in my case so clearly something is not right with the `instanceof String` check. 

Feel free to ignore the pull request and just make the necessary changes you feel necessary. 
