### PR TITLE
Update package.json to include dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=0.2.6"
   },
   "dependencies": {
+    "sylvester": ">= 0.0.4",
     "underscore": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Classifier functionality has a dependency not listed in package.json.  This commit resolves this so users who use `npm install` won't have their code break.
