### PR TITLE
eliminate compress dependency, works with zlib feature in newer node

### DIFF
--- a/lib/natural/wordnet/wordnet_file.js
+++ b/lib/natural/wordnet/wordnet_file.js
@@ -50,8 +50,6 @@ function downloadFile(url, filePath, callback) {
 
   } catch (e) {
     /* fall through to the legacy code below */
-    console.log(e);
-    return;
   }
 
 


### PR DESCRIPTION
That compress dependency is problematic, especially since compress doesn't build for me with a 0.6.x node.

Luckily, node ships with a zlib module that can be used much more succinctly.  This patch attempts to do so while allowing a fall back to the older logic for backwards compatibility purposes.
