### PR TITLE
fix global var leakage

### DIFF
--- a/lib/natural/inflectors/singular_plural_inflector.js
+++ b/lib/natural/inflectors/singular_plural_inflector.js
@@ -73,6 +73,7 @@ TenseInflector.prototype.addIrregular = function(singular, plural) {
 };
 
 TenseInflector.prototype.izeRegExps = function(token, forms) {
+        var i, form;
         for(i = 0; i < forms.length; i++) {
             form = forms[i];
             


### PR DESCRIPTION
Mocha notified me about the namespace leakage of the vars "i" and "form". I fixed it to make my tests pass :)
