### PR TITLE
Added removeDocument and retrain

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -45,6 +45,33 @@ function addDocument(text, classification) {
     }
 }
 
+function removeDocument(text, classification) {
+  var docs = this.docs
+    , doc
+    , pos;
+
+  if (typeof text === 'string') {
+    text = this.stemmer.tokenizeAndStem(text);
+  }
+
+  for (var i = 0, ii = docs.length; i < ii; i++) {
+    doc = docs[i];
+    if (doc.text.join(' ') == text.join(' ') &&
+        doc.label == classification) {
+      pos = i;
+    }
+  }
+
+  // Remove if there's a match
+  if (!isNaN(pos)) {
+    this.docs.splice(pos, 1);
+
+    for (var i = 0, ii = text.length; i < ii; i++) {
+      delete this.features[text[i]];
+    }
+  }
+}
+
 function textToFeatures(observation) {
     var features = [];
 
@@ -69,6 +96,12 @@ function train() {
     }
 
     this.classifier.train();
+}
+
+function retrain() {
+  this.classifier = new (this.classifier.constructor)();
+  this.lastAdded = 0;
+  this.train();
 }
 
 function getClassifications(observation) {
@@ -106,7 +139,9 @@ function load(filename, callback) {
 }
 
 Classifier.prototype.addDocument = addDocument;
+Classifier.prototype.removeDocument = removeDocument;
 Classifier.prototype.train = train;
+Classifier.prototype.retrain = retrain;
 Classifier.prototype.classify = classify;
 Classifier.prototype.textToFeatures = textToFeatures;
 Classifier.prototype.save = save;


### PR DESCRIPTION
Wanted the ability to remove something from a category, so I added the `removeDocument` method. However, looks like `train` is both incremental, and additive-only, so it seemed like the most straightforward way to do it without a lot of rewriting was to add a `retrain` that would wipe the slate and start over.

The only thing I'm really dubious about is the ramifications of removing a text-item from `features`, in the case where the same thing exists in documents with multiple classifiers.

If this is completely crazy, I'd appreciate feedback on a better way to approach adding this feature.

I've also added a test for this -- the test for good/bad equality seems a little brittle, but as long as the classifications format doesn't change, it should work correctly. I am a little curious how the `classify` method returns a value in the case where categorizations are all equal. Does it just pick the first one it finds? Is this desirable behavior? If something can't be reasonably categorized, would returning null be too weird?

Thanks for the work on this. I plan to use this in a Hack Day project at Yammer. :)
