### PR TITLE
fix extra binary search steps when word not found

### DIFF
--- a/lib/natural/wordnet/index_file.js
+++ b/lib/natural/wordnet/index_file.js
@@ -1,4 +1,4 @@
-/*  
+/*
 Copyright (c) 2011, Chris Umbel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -31,7 +31,6 @@ function getFileSize(path) {
 
 function findPrevEOL(fd, pos, callback) {
   var buff = new Buffer(1024);
-    
   if(pos == 0)
     callback(0);
   else {
@@ -46,7 +45,6 @@ function findPrevEOL(fd, pos, callback) {
 
 function readLine(fd, pos, callback) {
   var buff = new Buffer(1024);
-
   findPrevEOL(fd, pos, function(pos) {
     WordNetFile.appendLineChar(fd, pos, 0, buff, callback);
   });
@@ -56,25 +54,25 @@ function miss(callback) {
   callback({status: 'miss'});
 }
 
-function findAt(fd, size, pos, lastPos, adjustment, searchKey, callback) {
+function findAt(fd, size, pos, lastPos, adjustment, searchKey, callback, lastKey) {
   if (lastPos == pos || pos >= size) {
     miss(callback);
   } else {
     readLine(fd, pos, function(line) {
       var tokens = line.split(/\s+/);
       var key = tokens[0];
-    
+
     if(key == searchKey) {
         callback({status: 'hit', key: key, 'line': line, tokens: tokens});
-      } else if(adjustment == 1)  {
+      } else if(adjustment == 1 || key == lastKey)  {
         miss(callback);
-      } else {      
+      } else {
         adjustment = Math.ceil(adjustment * 0.5);
 
         if (key < searchKey) {
-          findAt(fd, size, pos + adjustment, pos, adjustment, searchKey, callback);
+          findAt(fd, size, pos + adjustment, pos, adjustment, searchKey, callback, key);
         } else {
-          findAt(fd, size, pos - adjustment, pos, adjustment, searchKey, callback);
+          findAt(fd, size, pos - adjustment, pos, adjustment, searchKey, callback, key);
         }
       }
     });
@@ -83,14 +81,14 @@ function findAt(fd, size, pos, lastPos, adjustment, searchKey, callback) {
 
 function find(searchKey, callback) {
   var indexFile = this;
-  
-  indexFile.open(function(err, fd, done) {    
+
+  indexFile.open(function(err, fd, done) {
     if(err) {
       console.log(err);
     } else {
       var size = getFileSize(indexFile.filePath) - 1;
       var pos = Math.ceil(size / 2);
-      findAt(fd, size, pos, null, pos, searchKey, 
+      findAt(fd, size, pos, null, pos, searchKey,
         function(result) { callback(result); done(); });
     }
   });
@@ -102,13 +100,13 @@ function lookupFromFile(word, callback) {
 
     if(record.status == 'hit') {
       var ptrs = [], offsets = [];
-      
+
       for(var i = 0; i < parseInt(record.tokens[3]); i++)
         ptrs.push(record.tokens[i]);
-        
+
       for(var i = 0; i < parseInt(record.tokens[2]); i++)
         offsets.push(parseInt(record.tokens[ptrs.length + 6 + i], 10));
-  
+
       indexRecord = {
         lemma: record.tokens[0],
         pos: record.tokens[1],
@@ -118,7 +116,7 @@ function lookupFromFile(word, callback) {
         synsetOffset:  offsets
       };
     }
-    
+
     callback(indexRecord);
   });
 }
@@ -136,5 +134,7 @@ util.inherits(IndexFile, WordNetFile);
 IndexFile.prototype.lookupFromFile = lookupFromFile;
 IndexFile.prototype.lookup = lookup;
 IndexFile.prototype.find = find;
+
+IndexFile.prototype._findAt = findAt;
 
 module.exports = IndexFile;


### PR DESCRIPTION
While doing some benchmarking, I noticed the binary search in index files performs extra iterations when a word is not found.  For example, searching for 'acre-' in index.noun, findAt() recursion:

1 2393327 'acre-' 'judgement_day' 2393327
2 1196663 'acre-' 'direct_sum' 1196664
3 598331 'acre-' 'buyout_bid' 598332
4 299165 'acre-' 'attraction' 299166
5 149582 'acre-' 'amorphophallus_campanulatus' 149583
6 74790 'acre-' 'agapanthus' 74792
7 37394 'acre-' 'acorn_barnacle' 37396
8 56092 'acre-' 'administrative_division' 18698
9 46743 'acre-' 'acular' 9349
10 42068 'acre-' 'acrylonitrile-butadiene-styrene' 4675
11 39730 'acre-' 'acridity' 2338
12 38561 'acre-' 'acousticophobia' 1169
13 39146 'acre-' 'acquisition' 585
14 39439 'acre-' 'acrasiomycetes' 293
15 39586 'acre-' 'acreage' 147
16 39512 'acre-' 'acre-foot' 74
17 39475 'acre-' 'acre' 37
18 39494 'acre-' 'acre' 19
19 39504 'acre-' 'acre-foot' 10
20 39499 'acre-' 'acre' 5
21 39502 'acre-' 'acre-foot' 3
22 39500 'acre-' 'acre' 2
23 39501 'acre-' 'acre' 1

It finally stops when adjustment (last param) == 1.  Steps after iteration 18 are unnecessary since it landed on the same line as before.  This patch fixes that by adding a lastKey parameter to findAt().

I've also exposed IndexFile.prototype._findAt() for some optimization work I'm doing.
