### PR TITLE
Fixing a second bug identified in issue #44

### DIFF
--- a/lib/natural/distance/jaro-winkler_distance.js
+++ b/lib/natural/distance/jaro-winkler_distance.js
@@ -43,19 +43,29 @@ function distance(s1, s2) {
 
     // find matches
     for (var i = 0; i < s1.length; i++) {
-	   var matched = false;
+	var matched = false;
 
-        // this for loop is a little brutal
-        for (k = (i <= matchWindow) ? 0 : i - matchWindow;
-                 (k <= i + matchWindow) && k < s2.length && !matched; k++) {
-            if (s1[i] == s2[k]) {
-                if(!matches1[i] && !matches2[k]) {
-                    m++;
-                }
+	// check for an exact match
+	if (s1[i] ==  s2[i]) {
+		matches1[i] = matches2[i] = matched = true;
+		m++
+	}
 
-                matches1[i] = matches2[k] = matched = true;
-            }
-        }
+	// check the "match window"
+	else {
+        	// this for loop is a little brutal
+        	for (k = (i <= matchWindow) ? 0 : i - matchWindow;
+        		(k <= i + matchWindow) && k < s2.length && !matched;
+			k++) {
+            		if (s1[i] == s2[k]) {
+                		if(!matches1[i] && !matches2[k]) {
+                	    		m++;
+               		}
+
+        	        matches1[i] = matches2[k] = matched = true;
+        	    }
+        	}
+	}
     }
 
     if(m == 0)

--- a/spec/jaro-winkler_spec.js
+++ b/spec/jaro-winkler_spec.js
@@ -36,6 +36,7 @@ describe('jaro-winkler', function () {
         expect(jaroWinklerDistance('RICK', 'RICK')).toBe(1);
         expect(jaroWinklerDistance('abc', 'abc')).toBe(1);
         expect(jaroWinklerDistance('abcd', 'abcd')).toBe(1);
+        expect(jaroWinklerDistance('seddon', 'seddon')).toBe(1);
     });
 
     it('should handle total mis-matches', function () {


### PR DESCRIPTION
When there was a duplicate letter in a string, it would count the first occurrence of the letter, which means that it thought there was a letter transposition, when that wasn't the case. Added explicit check to see if there was an exact string position match first, then check to see if there is a matching letter in the "match window"
