### PR TITLE
Fixed small typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ A classifier can also be serialized and deserialized like so:
     // serialize
     var raw = JSON.stringify(classifier);
     // deserialize
-    var restoredClassifier = natural.BayesClassifier.restore(raw);
+    var restoredClassifier = natural.BayesClassifier.restore(JSON.parse(raw));
     console.log(restoredClassifier.classify('i should sell that'));
 
 Phonetics


### PR DESCRIPTION
Hey, 

Love the library! Thank you for creating and maintaining it. Just thought I would fix a small problem with the documentation I came across today. When loading a classifier from a raw JSON string the JSON string needs to be parsed first or else it throws this error:

```
/home/jkimbo/code/categories/node_modules/natural/node_modules/apparatus/lib/apparatus/classifier/logistic_regression_classifier.js:174
    classifier.__proto__ = LogisticRegressionClassifier.prototype;
                         ^
TypeError: Cannot set property '__proto__' of undefined
    at Function.restore (/home/jkimbo/code/categories/node_modules/natural/node_modules/apparatus/lib/apparatus/classifier/logistic_regression_classifier.js:174:26)
    at Function.restore (/home/jkimbo/code/categories/node_modules/natural/lib/natural/classifiers/logistic_regression_classifier.js:37:67)
    at Query.output.load [as _callback] (/home/jkimbo/code/categories/ai.js:13:47)
    at Sequence.end (/home/jkimbo/code/categories/node_modules/mysql/lib/protocol/sequences/Sequence.js:68:22)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

Thanks again!
