### PR TITLE
Custom stemmer ignored

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -32,7 +32,7 @@ var BayesClassifier = function(stemmer) {
 util.inherits(BayesClassifier, Classifier);
 
 function restore(classifier, stemmer) {
-    classifier = Classifier.restore(classifier);
+    classifier = Classifier.restore(classifier, stemmer);
     classifier.__proto__ = BayesClassifier.prototype;
     classifier.classifier = ApparatusBayesClassifier.restore(classifier.classifier);
 
@@ -41,7 +41,7 @@ function restore(classifier, stemmer) {
 
 function load(filename, stemmer, callback) {
     Classifier.load(filename, function(err, classifier) {
-        callback(err, restore(classifier));
+        callback(err, restore(classifier, stemmer));
     });
 }
 


### PR DESCRIPTION
When loading a Bayes-Classifier from JSON any custom stemmer that gets passed is ignored, because the stemmer variable is passed on improperly.
