### PR TITLE
Fix passing classfier to save() callback

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -87,7 +87,12 @@ function restore(classifier, stemmer) {
 function save(filename, callback) {
     var data = JSON.stringify(this);
     var fs = require('fs');
-    fs.writeFile(filename, data, encoding='utf8', callback);
+    var classifier = this;
+    fs.writeFile(filename, data, encoding='utf8', function(err) {
+        if(callback) {
+            callback(err, err ? null : classifier);
+        }
+    });
 }
 
 function load(filename, callback) {


### PR DESCRIPTION
fs.writeFile has only on parameter to callback, which is the error callback (see here: http://nodejs.org/api/fs.html#fs_fs_writefile_filename_data_encoding_callback) - so the written classifier never gets passed back to the given callback.
