### PR TITLE
Fix paramaters

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -88,7 +88,7 @@ function save(filename, callback) {
     var data = JSON.stringify(this);
     var fs = require('fs');
     var classifier = this;
-    fs.writeFile(filename, data, encoding='utf8', function(err) {
+    fs.writeFile(filename, data, 'utf8', function(err) {
         if(callback) {
             callback(err, err ? null : classifier);
         }
@@ -98,7 +98,7 @@ function save(filename, callback) {
 function load(filename, callback) {
     var fs = require('fs');
 
-    fs.readFile(filename, encoding='utf8', function(err, data) {
+    fs.readFile(filename, 'utf8', function(err, data) {
         var classifier;
           
         if(!err) {


### PR DESCRIPTION
JS does not have parameter names - they were probably copied over from the node.js FS documentation unintentionally.
