### PR TITLE
Unnecessary usage of the new operator

### DIFF
--- a/lib/natural/phonetics/phonetic.js
+++ b/lib/natural/phonetics/phonetic.js
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 var stopwords = require('../util/stopwords');
-var Tokenizer = new require('../tokenizers/aggressive_tokenizer')
+var Tokenizer = require('../tokenizers/aggressive_tokenizer')
     tokenizer = new Tokenizer();
 
 module.exports = function() {


### PR DESCRIPTION
A tokenizer object is created on the next line, the Tokenizer variable should be a pure function with a filled prototype and not another object.

I was using browserify to get client-sided phonetics and stumbled upon this mistake. Browserify failed on embedding the aggressive tokenizer, fixing this mistake also fixed the browserifying of phonetics.
