### PR TITLE
Ignore empty documents

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -34,6 +34,11 @@ var Classifier = function(classifier, stemmer) {
 function addDocument(text, classification) {
     if(typeof text === 'string')
 	text = this.stemmer.tokenizeAndStem(text);
+    
+    if(text.length === 0) {
+        // ignore empty documents
+        return;
+    }
 
     this.docs.push({
 	label: classification,


### PR DESCRIPTION
When calling 

`classifier.addDocument("","someClass");`
or
`classifier.addDocument([],"someClass");`

there is no real value added, as the class gets added to the classifier, but there is no data to base any classification on - ergo probability for this class will always be 0% - this pull request fixes this by not adding the empty data at all and thus making sure that the classifier does not get unnecessarily bloated.
