### PR TITLE
Fix the default substitution cost for Levenshtein distance

### DIFF
--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -33,7 +33,7 @@ function LevenshteinDistance (source, target, options) {
     options = options || {};
     options.insertion_cost = options.insertion_cost || 1;
     options.deletion_cost = options.deletion_cost || 1;
-    options.substitution_cost = options.substitution_cost || 2;
+    options.substitution_cost = options.substitution_cost || 1;
 
     var sourceLength = source.length;
     var targetLength = target.length;


### PR DESCRIPTION
Fix the default substitution cost for Levenshtein distance which should be 1 [1](http://en.wikipedia.org/wiki/Levenshtein_distance)

E.g. "kitten" -> "sitting" the correct Levenshtein distance should be 3. Before this fix natural package returns 5.
