### PR TITLE
WordNet: break synset attribute "gloss" into 2 seperate attributes, definition and examples

### DIFF
--- a/lib/natural/wordnet/data_file.js
+++ b/lib/natural/wordnet/data_file.js
@@ -51,7 +51,7 @@ function get(location, callback) {
       }
 
       // break "gloss" into definition vs. examples
-      var glossArray = tokens[1].split("; ");
+      var glossArray = data[1].split("; ");
       var definition = glossArray[0];
       var examples = glossArray.slice(1);    
       for (var k=0; k < examples.length; k++) {


### PR DESCRIPTION
The "gloss" attribute in the callback wasn't enough for my project. I've written the code to divide them into a definition and array of examples. Merge if you wish!
