### PR TITLE
TFIDF Performance Improvments

### DIFF
--- a/lib/natural/tfidf/tfidf.js
+++ b/lib/natural/tfidf/tfidf.js
@@ -102,6 +102,8 @@ TfIdf.prototype.addDocument = function(document, key, restoreCache) {
     }
 };
 
+// If restoreCache is set to true, all terms idf scores currently cached will be recomputed.
+// Otherwise, the cache will just be wiped clean
 TfIdf.prototype.addFileSync = function(path, encoding, key, restoreCache) {
     if(!encoding)
         encoding = 'UTF-8';

--- a/spec/test_data/tfidf_document1.txt
+++ b/spec/test_data/tfidf_document1.txt
@@ -1,0 +1,1 @@
+this document is about node.

--- a/spec/test_data/tfidf_document2.txt
+++ b/spec/test_data/tfidf_document2.txt
@@ -1,0 +1,1 @@
+this document is about ruby.

--- a/spec/test_data/tfidf_document3.txt
+++ b/spec/test_data/tfidf_document3.txt
@@ -1,0 +1,1 @@
+this document is about ruby and node.

--- a/spec/test_data/tfidf_document4.txt
+++ b/spec/test_data/tfidf_document4.txt
@@ -1,0 +1,1 @@
+this document is about node. it has node examples

--- a/spec/tfidf_spec.js
+++ b/spec/tfidf_spec.js
@@ -128,5 +128,49 @@ describe('tfidf', function() {
             expect( tfidf.tfidf("node", 0) ).toBe( 1 * Math.log( 4.0 / 3.0 ) );
         });
 
+        // Test tf-idf computation on files loaded using readFileSync
+        it("should load documents from files", function(){
+
+            tfidf = new TfIdf();
+
+            tfidf.addFileSync("spec/test_data/tfidf_document1.txt", null, {node: 0, ruby:1});
+            tfidf.addFileSync("spec/test_data/tfidf_document2.txt", null, {node:1, ruby:3});
+            tfidf.addFileSync("spec/test_data/tfidf_document3.txt", null, {node:0, ruby:3});
+            tfidf.addFileSync("spec/test_data/tfidf_document4.txt", null, {node:2, ruby:1});
+
+            var correctCalculations = [
+                1 * Math.log( 4.0 / 3.0 ),
+                0,
+                2 * Math.log( 4.0 / 3.0 ),
+                1 * Math.log( 4.0 / 2.0 )
+            ];
+
+            tfidf.tfidfs('node', function(i, measure, k) {
+                expect(measure).toBe(correctCalculations[k.node])
+            });
+
+            tfidf.tfidfs('ruby', function(i, measure, k) {
+                expect(measure).toBe(correctCalculations[k.ruby])
+            });
+        });
+
+        // Test idf caching when adding documents from addFileSync
+        if("should update a terms tf-idf score after adding documents from addFileSync", function(){
+            tfidf = new TfIdf();
+
+            // Add 2 documents
+            tfidf.addFileSync("spec/test_data/tfidf_document1.txt", 0);
+            tfidf.addFileSync("spec/test_data/tfidf_document2.txt", 1);
+
+            // check the tf-idf for 'node'
+            expect( tfidf.tfidf("node", 0) ).toBe( 1 * Math.log( 2.0 / 1.0 ) );
+
+            // Add 2 more documents
+            tfidf.addFileSync("spec/test_data/tfidf_document3.txt");
+            tfidf.addFileSync("spec/test_data/tfidf_document4.txt");
+
+            // Ensure that the tf-idf in the same document has changed to reflect the new idf.
+            expect( tfidf.tfidf("node", 0) ).toBe( 1 * Math.log( 4.0 / 3.0 ) );
+        });
     });
 });


### PR DESCRIPTION
Adding an IDF caching mechanism which reduces tfidfs time exponentially in most cases, also updated unit tests to include some untested functions.
