### PR TITLE
added length condition for verbs stem

### DIFF
--- a/lib/natural/stemmers/porter_stemmer.js
+++ b/lib/natural/stemmers/porter_stemmer.js
@@ -94,7 +94,7 @@ function step1a(token) {
     if(token.match(/(ss|i)es$/))
         return token.replace(/(ss|i)es$/, '$1');
  
-    if(token.substr(-1) == 's' && token.substr(-2, 1) != 's')
+    if(token.substr(-1) == 's' && token.substr(-2, 1) != 's' && token.length > 3)
         return token.replace(/s?$/, '');
     
     return token;
@@ -171,7 +171,7 @@ function step4(token) {
 function step5a(token) {
     var m = measure(token);
     
-    if((m > 1 && token.substr(-1) == 'e') || (m == 1 && !(categorizeChars(token).substr(-4, 3) == 'CVC' && token.match(/[^wxy].$/))))
+    if(token.length > 3 && ((m > 1 && token.substr(-1) == 'e') || (m == 1 && !(categorizeChars(token).substr(-4, 3) == 'CVC' && token.match(/[^wxy].$/)))))
         return token.replace(/e$/, '');
 
     return token;


### PR DESCRIPTION
short verbs like 'is', 'are' or 'has' got stemmed in the form of 'i', 'ar' and 'ha' which is incorrect.
added condition to exclude verbs of 3 characters or less from stemming
