### PR TITLE
'ies' finishing verbs' plural form to 'y'

### DIFF
--- a/lib/natural/inflectors/present_verb_inflector.js
+++ b/lib/natural/inflectors/present_verb_inflector.js
@@ -63,7 +63,8 @@ var VerbInflector = function() {
     this.pluralForms.regularForms.push([/xes$/i, 'x']);
     this.pluralForms.regularForms.push([/([cs])hes$/i, '$1h']);
     this.pluralForms.regularForms.push([/zzes$/i, 'zz']);
-    this.pluralForms.regularForms.push([/([^h|z|o])es$/i, '$1e']);
+    this.pluralForms.regularForms.push([/([^h|z|o|i])es$/i, '$1e']);
+    this.pluralForms.regularForms.push([/ies$/i, 'y']);//flies->fly
     this.pluralForms.regularForms.push([/e?s$/i, '']); 
 };
 


### PR DESCRIPTION
singular verbs like 'flies' or 'tries' were inflected to 'flie' and 'trie' instead of 'fly','try'
