### PR TITLE
Catch error when classifier file fails to load

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -41,6 +41,9 @@ function restore(classifier, stemmer) {
 
 function load(filename, stemmer, callback) {
     Classifier.load(filename, function(err, classifier) {
+        if (err) {
+            callback(err);
+        }
         callback(err, restore(classifier, stemmer));
     });
 }


### PR DESCRIPTION
Currently this just moves onto the restore method, which fails when there is no classifier loaded.
