### PR TITLE
Adds Tokenizer for the Dutch language.

### DIFF
--- a/lib/natural/index.js
+++ b/lib/natural/index.js
@@ -32,6 +32,7 @@ exports.PorterStemmerIt = require('./stemmers/porter_stemmer_it');
 exports.LancasterStemmer = require('./stemmers/lancaster_stemmer');
 exports.StemmerPl = require('./stemmers/stemmer_pl');
 exports.StemmerJa = require('./stemmers/stemmer_ja');
+exports.AggressiveTokenizerNl = require('./tokenizers/aggressive_tokenizer_nl');
 exports.AggressiveTokenizerFa = require('./tokenizers/aggressive_tokenizer_fa');
 exports.AggressiveTokenizerRu = require('./tokenizers/aggressive_tokenizer_ru');
 exports.AggressiveTokenizerEs = require('./tokenizers/aggressive_tokenizer_es');

--- a/lib/natural/tokenizers/aggressive_tokenizer_nl.js
+++ b/lib/natural/tokenizers/aggressive_tokenizer_nl.js
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2011, Chris Umbel, Martijn de Boer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+var Tokenizer = require('./tokenizer'),
+    util = require('util');
+
+var AggressiveTokenizer = function() {
+    Tokenizer.call(this);
+};
+util.inherits(AggressiveTokenizer, Tokenizer);
+
+module.exports = AggressiveTokenizer;
+
+AggressiveTokenizer.prototype.tokenize = function(text) {
+    // break a string up into an array of tokens by anything non-word
+    return this.trim(text.split(/[^a-zA-Z0-9_']+/));
+};

--- a/spec/aggressive_tokenizer_nl_spec.js
+++ b/spec/aggressive_tokenizer_nl_spec.js
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2011, Chris Umbel, Martijn de Boer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this softwé and associated documentation files (the "Softwé"), to deal
+in the Softwé without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Softwé, and to permit persons to whom the Softwé is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Softwé.
+
+THE SOFTWé IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWé OR THE USE OR OTHER DEALINGS IN
+THE SOFTWé.
+*/
+
+var Tokenizer = require('../lib/natural/tokenizers/aggressive_tokenizer_nl'),
+    tokenizer = new Tokenizer();
+
+describe('aggressive_tokenizer_nl', function() {
+  it('should tokenize strings', function() {
+    expect(tokenizer.tokenize('\'s Morgens is het nog erg koud, vertelde de weerman over een van de radio\'s')).toEqual(['\'s','Morgens','is','het','nog','erg','koud','vertelde','de','weerman','over','een','van','de','radio\'s']);
+  });
+
+  it('should tokenize strings via attached string method', function() {
+    tokenizer.attach();
+    expect('\'s Morgens is het nog erg koud, vertelde de weerman over een van de radio\'s'.tokenize()).toEqual(['\'s','Morgens','is','het','nog','erg','koud','vertelde','de','weerman','over','een','van','de','radio\'s']);
+  });
+
+});


### PR DESCRIPTION
Adds a tokenizer adhering to the use of a single quote for the Dutch language. (Used in some plural forms, and also when shortening older words like des).

I was unable to get jasmine running a test, but added a test for the tokeniser blindly. It should pass, as testing in a regular script works.

Will be adding more Dutch language related work soon.
