### PR TITLE
Accepts an optional smoothing parameter for the Bayesian estimates.

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -25,8 +25,12 @@ util = require('util'),
 Classifier = require('./classifier'),
 ApparatusBayesClassifier = require('apparatus').BayesClassifier;
 
-var BayesClassifier = function(stemmer) {
-    Classifier.call(this, new ApparatusBayesClassifier(), stemmer);
+var BayesClassifier = function(stemmer, smoothing) {
+    var abc = new ApparatusBayesClassifier();
+    if (smoothing && isFinite(smoothing)) {
+        abc = new ApparatusBayesClassifier(smoothing);
+    }
+    Classifier.call(this, abc, stemmer);
 };
 
 util.inherits(BayesClassifier, Classifier);

--- a/spec/bayes_classifier_spec.js
+++ b/spec/bayes_classifier_spec.js
@@ -157,5 +157,17 @@ describe('bayes classifier', function() {
 		  });
             });
 	});
+
+
+        it('should accept an optional smoothing parameter for the Bayesian estimates', function() {
+            var defaultClassifier = new natural.BayesClassifier();
+            var PorterStemmer = require('../lib/natural/stemmers/porter_stemmer');
+            var newClassifier1 = new natural.BayesClassifier(PorterStemmer);
+            var newClassifier2 = new natural.BayesClassifier(PorterStemmer, 0.1);
+
+            expect(defaultClassifier.classifier.smoothing).toBe(1.0);
+            expect(newClassifier1.classifier.smoothing).toBe(1.0);
+            expect(newClassifier2.classifier.smoothing).toBe(0.1);
+        });
     });
 });


### PR DESCRIPTION
The underlying Bayes classifier (in Apparatus) already incorporates a smoothing parameter, but there's no easy way to change it from its default within Natural. Proposed changes here will allow a third parameter to specify the smoothing value.
