### PR TITLE
Transposition loop should check var i and not var k

### DIFF
--- a/lib/natural/distance/jaro-winkler_distance.js
+++ b/lib/natural/distance/jaro-winkler_distance.js
@@ -75,7 +75,7 @@ function distance(s1, s2) {
     var k = 0;
 
     for(var i = 0; i < s1.length; i++) {
-    	if(matches1[k]) {
+        if(matches1[i]) {
     	    while(!matches2[k] && k < matches2.length)
                 k++;
 	        if(s1[i] != s2[k] &&  k < matches2.length)  {


### PR DESCRIPTION
Tranposition loop in JaroWinkler Distance Function needs to be checking first for the existence of a match in the first string using "i" rather than "k"