### PR TITLE
Fix normalize_ja more natural

### DIFF
--- a/lib/natural/normalizers/normalizer_ja.js
+++ b/lib/natural/normalizers/normalizer_ja.js
@@ -120,26 +120,21 @@ var conversionTables = {
       '９': '9'
     },
 
-    punctuation: {
+    symbol: {
       '＿': '_',
       '－': '-',
-      '・': '･',
       '，': ',',
-      '、': '､',
       '；': ';',
       '：': ':',
       '！': '!',
       '？': '?',
       '．': '.',
-      '。': '｡',
       '（': '(',
       '）': ')',
       '［': '[',
       '］': ']',
       '｛': '{',
       '｝': '}',
-      '「': '｢',
-      '」': '｣',
       '＠': '@',
       '＊': '*',
       '＼': '\\',
@@ -154,13 +149,23 @@ var conversionTables = {
       '＝': '=',
       '＞': '>',
       '｜': '|',
-      '～': '~',
+      // Never converted: '～': '~',
       '≪': '«',
       '≫': '»',
       '─': '-',
       '＄': '$',
       '＂': '"'
     },
+
+    purePunctuation: {
+      '、': '､',
+      '。': '｡',
+      '・': '･',
+      '「': '｢',
+      '」': '｣'
+    },
+
+    punctuation: {},
 
     katakana: {
       '゛': 'ﾞ',
@@ -492,9 +497,17 @@ var fixCompositeSymbolsTable = {
   '㍗': 'ワット'
 };
 
+// punctuation is pure_punctuation
+conversionTables.fullwidthToHalfwidth.punctuation = merge(
+    conversionTables.fullwidthToHalfwidth.symbol,
+    conversionTables.fullwidthToHalfwidth.purePunctuation
+)
+
 // Fill in the conversion tables with the flipped tables.
 conversionTables.halfwidthToFullwidth.alphabet = flip(conversionTables.fullwidthToHalfwidth.alphabet);
 conversionTables.halfwidthToFullwidth.numbers = flip(conversionTables.fullwidthToHalfwidth.numbers);
+conversionTables.halfwidthToFullwidth.symbol = flip(conversionTables.fullwidthToHalfwidth.symbol);
+conversionTables.halfwidthToFullwidth.purePunctuation = flip(conversionTables.fullwidthToHalfwidth.purePunctuation);
 conversionTables.halfwidthToFullwidth.punctuation = flip(conversionTables.fullwidthToHalfwidth.punctuation);
 conversionTables.halfwidthToFullwidth.katakana = flip(conversionTables.fullwidthToHalfwidth.katakana);
 
@@ -502,7 +515,8 @@ conversionTables.halfwidthToFullwidth.katakana = flip(conversionTables.fullwidth
 conversionTables.normalize = merge(
     conversionTables.fullwidthToHalfwidth.alphabet,
     conversionTables.fullwidthToHalfwidth.numbers,
-    conversionTables.halfwidthToFullwidth.punctuation,
+    conversionTables.fullwidthToHalfwidth.symbol,
+    conversionTables.halfwidthToFullwidth.purePunctuation,
     conversionTables.halfwidthToFullwidth.katakana
     );
 
@@ -510,6 +524,8 @@ var converters = {
   fullwidthToHalfwidth: {
     alphabet: replacer(conversionTables.fullwidthToHalfwidth.alphabet),
     numbers: replacer(conversionTables.fullwidthToHalfwidth.numbers),
+    symbol: replacer(conversionTables.fullwidthToHalfwidth.symbol),
+    purePunctuation: replacer(conversionTables.fullwidthToHalfwidth.purePunctuation),
     punctuation: replacer(conversionTables.fullwidthToHalfwidth.punctuation),
     katakana: replacer(conversionTables.fullwidthToHalfwidth.katakana)
   },
@@ -517,6 +533,8 @@ var converters = {
   halfwidthToFullwidth: {
     alphabet: replacer(conversionTables.halfwidthToFullwidth.alphabet),
     numbers: replacer(conversionTables.halfwidthToFullwidth.numbers),
+    symbol: replacer(conversionTables.halfwidthToFullwidth.symbol),
+    purePunctuation: replacer(conversionTables.halfwidthToFullwidth.purePunctuation),
     punctuation: replacer(conversionTables.halfwidthToFullwidth.punctuation),
     katakana: replacer(conversionTables.halfwidthToFullwidth.katakana)
   },

--- a/spec/normalizer_ja_spec.js
+++ b/spec/normalizer_ja_spec.js
@@ -54,8 +54,14 @@ describe('normalize_ja', function() {
 
   it('should transform halfwidth punctuation signs to fullwidth', function() {
     // Taken from http://unicode.org/cldr/trac/browser/trunk/common/main/ja.xml
-    expect(normalize_ja('‾ _＿ -－ ‐ — ― 〜 ・ ･ ,， 、､ ;； :： !！ ?？ .． ‥ … 。｡ ＇＼ ‘ ’ "＂ “ ” (（ )） [［ ]］ {｛ }｝ 〈 〉 《 》 「｢ 」｣ 『 』 【 】 〔 〕 ‖ § ¶ @＠ +＋ ^＾ $＄ *＊ /／ ＼\\ &＆ #＃ %％ ‰ † ‡ ′ ″ 〃 ※'))
-      .toEqual('‾ ＿＿ ─－ ‐ — ― 〜 ・ ・ ，， 、、 ；； ：： ！！ ？？ ．． ‥ … 。。 ＇＼ ‘ ’ ＂＂ “ ” （（ ）） ［［ ］］ ｛｛ ｝｝ 〈 〉 《 》 「「 」」 『 』 【 】 〔 〕 ‖ § ¶ ＠＠ ＋＋ ＾＾ ＄＄ ＊＊ ／／ ＼＼ ＆＆ ＃＃ ％％ ‰ † ‡ ′ ″ 〃 ※');
+    expect(normalize_ja('〜 ・ ･ 、､ 。｡ 「｢ 」｣'))
+      .toEqual('〜 ・ ・ 、、 。。 「「 」」');
+  });
+
+  it('should transform fullwidth symbols to halfwidth', function() {
+    // Taken from http://unicode.org/cldr/trac/browser/trunk/common/main/ja.xml
+    expect(normalize_ja('‾ _＿ -－ ‐ — ― ,， ;； :： !！ ?？ .． ‥ … ＇＼ ‘ ’ "＂ “ ” (（ )） [［ ]］ {｛ }｝ 〈 〉 《 》 『 』 【 】 〔 〕 ‖ § ¶ @＠ +＋ ^＾ $＄ *＊ /／ ＼\\ &＆ #＃ %％ ‰ † ‡ ′ ″ 〃 ※'))
+      .toEqual('‾ __ -- ‐ — ― ,, ;; :: !! ?? .. ‥ … ＇\\ ‘ ’ "" “ ” (( )) [[ ]] {{ }} 〈 〉 《 》 『 』 【 】 〔 〕 ‖ § ¶ @@ ++ ^^ $$ ** // \\\\ && ## %% ‰ † ‡ ′ ″ 〃 ※');
   });
 
   it('should replace repeat characters', function() {
@@ -65,7 +71,7 @@ describe('normalize_ja', function() {
 
   it('should replace composite symbols', function() {
     expect(normalize_ja('㍼54年㋃㏪')).toEqual('昭和54年4月11日');
-    expect(normalize_ja('㍧~㍬')).toEqual('15点～20点');
+    expect(normalize_ja('㍧〜㍬')).toEqual('15点〜20点');
     expect(normalize_ja('カンパニー㍿')).toEqual('カンパニー株式会社');
     expect(normalize_ja('100㌫')).toEqual('100パーセント');
     expect(normalize_ja('70㌔')).toEqual('70キロ');


### PR DESCRIPTION
For natural Japanese text, full-width/half-width translation should be more complex.
I changed converter rule more suitable. This behavior is close to PHP's one which oftenly used by Japanese users.

``` php
$expected = '「NodeJS」の0.11(.0)が、ベータ・リリースされます〜。~>';  // beautiful form
$dirty = '「ＮｏｄｅJS｣の０．１１（.０)が､ベータ･ﾘﾘｰｽされます〜｡~＞';  // dirty input
echo mb_convert_kana($dirty, 'KVa', 'utf-8') == $expected; // --> true!
```

See 1st example of http://php.net/manual/en/function.mb-convert-kana.php

Totally we Japanese prefer half-width symbols than full-width as much as possible. But some of half-width punctuations (`。、・`) are not supported by our domestic encodings: Shift_JIS, EUC-JP and ISO-2022-JP.

Full-width `〜` should never converted. It has different semantic to half-width `~`. PHP also do nothing to `~`.
