### PR TITLE
Declare forgotten vars detected with use strict in French Porter Stemmer

### DIFF
--- a/lib/natural/stemmers/porter_stemmer_fr.js
+++ b/lib/natural/stemmers/porter_stemmer_fr.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
 Copyright (c) 2014, Ismaël Héry
 
@@ -50,7 +52,8 @@ function stem(token) {
     return token;
 
   var regs = regions(token);
-  //console.log('regions:', regs)
+
+  var r1_txt, r2_txt, rv_txt;
   r1_txt = token.substring(regs.r1);
   r2_txt = token.substring(regs.r2);
   rv_txt = token.substring(regs.rv);
@@ -269,8 +272,10 @@ function stem(token) {
  * @return {Object}       Regions r1, r2, rv as offsets from the begining of the word
  */
 function regions(token) {
-  var r1 = r2 = rv = len = token.length;
+  var r1, r2, rv, len;
   var i;
+
+  r1 = r2 = rv = len = token.length;
 
   // R1 is the region after the first non-vowel following a vowel,
   for (var i = 0; i < len - 1 && r1 == len; i++) {


### PR DESCRIPTION
I've forgotten to initialize some vars in the French Porter Stemmer I contributed a few months ago.
