### PR TITLE
JaroWinkler performance tweak

### DIFF
--- a/lib/natural/distance/jaro-winkler_distance.js
+++ b/lib/natural/distance/jaro-winkler_distance.js
@@ -99,13 +99,18 @@ function distance(s1, s2) {
 // s2 is the second string to compare
 // dj is the Jaro Distance (if you've already computed it), leave blank and the method handles it
 function JaroWinklerDistance(s1, s2, dj) {
-    var jaro;
-    (typeof(dj) == 'undefined')? jaro = distance(s1,s2) : jaro = dj;
-    var p = 0.1; //
-    var l = 0 // length of the matching prefix
-    while(s1[l] == s2[l] && l < 4)
-        l++;
-    
-    return jaro + l * p * (1 - jaro);
+		if (s1 == s2) {
+				return 1 
+		}
+		else {
+		    var jaro;
+		    (typeof(dj) == 'undefined')? jaro = distance(s1,s2) : jaro = dj;
+		    var p = 0.1; //
+		    var l = 0 // length of the matching prefix
+		    while(s1[l] == s2[l] && l < 4)
+		        l++;
+		    
+		    return jaro + l * p * (1 - jaro);
+		}
 }
 module.exports = JaroWinklerDistance;


### PR DESCRIPTION
I needed a slight performance tweak for a project I am working on, which utilizes JaroWinkler in a high traffic environment.  The change is that if string1 = string2, simply return 1 (bypassing the rest of the JaroWinkler
calculation).
