### PR TITLE
Add coverage for BayesClassifier.

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -46,7 +46,7 @@ function restore(classifier, stemmer) {
 function load(filename, stemmer, callback) {
     Classifier.load(filename, function(err, classifier) {
         if (err) {
-            callback(err);
+            return callback(err);
         }
         callback(err, restore(classifier, stemmer));
     });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "uubench": "0.0.x",
+    "sinon": "^1.12.2",
     "jasmine-node": "~1.13.1"
   },
   "scripts": {

--- a/spec/bayes_classifier_spec.js
+++ b/spec/bayes_classifier_spec.js
@@ -21,6 +21,8 @@ THE SOFTWARE.
 */
 
 var natural = require('../lib/natural');
+var sinon = require('sinon');
+var baseClassifier = require('lib/natural/classifiers/classifier.js');
 
 describe('bayes classifier', function() {
     describe('classifier', function() {
@@ -168,6 +170,29 @@ describe('bayes classifier', function() {
             expect(defaultClassifier.classifier.smoothing).toBe(1.0);
             expect(newClassifier1.classifier.smoothing).toBe(1.0);
             expect(newClassifier2.classifier.smoothing).toBe(0.1);
+        });
+    });
+
+    describe('load', function () {
+
+        var sandbox;
+
+        beforeEach(function () {
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('should pass an error to the callback function', function () {
+            sandbox.stub(baseClassifier, 'load', function (filename, cb) {
+                cb(new Error('An error occurred'));
+            });
+            natural.BayesClassifier.load('/spec/test_data/tfidf_document1.txt', null, function (err, newClassifier) {
+                expect(err).toBe.ok;
+                expect(newClassifier).not.toBe.ok;
+            });
         });
     });
 });

--- a/spec/classifier_spec.js
+++ b/spec/classifier_spec.js
@@ -165,7 +165,7 @@ describe('classifier', function () {
             expect(result).not.toBe.ok;
         });
 
-        it('does nothing if called without a callback', function () {
+        it('does nothing if called with a nonexistent filename', function () {
             result = baseClassifier.load('/nonexistentFilename', function (err, newClassifier){
                 expect(err).toBe.ok;
                 expect(newClassifier).not.toBe.ok;


### PR DESCRIPTION
Adds coverage for error condition in BayesClassifier.load.

Also fixes bug in error condition in which the function was not returning after calling the callback with an error. This caused the function attempt to go on to the non-error case, which caused an error.

Also fixes my own mis-naming of a test case in spec/classifier_spec.js. The nonexistent filename case was not running because it had the same name as the "called without callback" case.
