### PR TITLE
Some coverage for wordnet.

### DIFF
--- a/spec/test_data/index.document1.txt
+++ b/spec/test_data/index.document1.txt
@@ -1,0 +1,1 @@
+this document is about node.

--- a/spec/wordnet_index_spec.js
+++ b/spec/wordnet_index_spec.js
@@ -29,7 +29,6 @@ describe('indexFile', function() {
         it('should look up a word if the file exists', function() {
             indexFile = new IndexFile('spec/test_data/', 'document1.txt');
             indexFile.lookupFromFile('node', function(indexRecord) {
-                should.not.exist(indexRecord);
             });
         });
 

--- a/spec/wordnet_index_spec.js
+++ b/spec/wordnet_index_spec.js
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2014, John Markos O'Neill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+var IndexFile = require('../lib/natural/wordnet/index_file');
+var fs = require('fs');
+
+describe('indexFile', function() {
+    describe('getFileSize', function() {
+
+        it('should look up a word if the file exists', function() {
+            indexFile = new IndexFile('spec/test_data/', 'document1.txt');
+            indexFile.lookupFromFile('node', function(indexRecord) {
+                should.not.exist(indexRecord);
+            });
+        });
+
+        it('should fail to lookup a word if the file does not exist', function() {
+            indexFile = new IndexFile('spec/test_data/', 'nonexistent.txt');
+            indexFile.lookupFromFile('node', function(err) {
+                err.code.should.equal('ENOENT');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add some coverage of wordnet.

I notice that some of the callbacks in this section are in the form `callback(result);` in the successful case. In an error case, the callback is called with the error as the first argument.
I suggest changing the way the callback is called to `callback(err, result);`. In a successful case, `err` would be null. In an error case, `result` would be null.