### PR TITLE
Tokenize and stem bug

### DIFF
--- a/lib/natural/stemmers/stemmer.js
+++ b/lib/natural/stemmers/stemmer.js
@@ -40,11 +40,21 @@ module.exports = function() {
 
     stemmer.tokenizeAndStem = function(text, keepStops) {
         var stemmedTokens = [];
-        
-        new Tokenizer().tokenize(text).forEach(function(token) {
-            if(keepStops || stopwords.words.indexOf(token) == -1)
+        var lowercaseText = text.toLowerCase();
+        var tokens = new Tokenizer().tokenize(lowercaseText);
+
+        if (keepStops) {
+            tokens.forEach(function(token) {
                 stemmedTokens.push(stemmer.stem(token));
-        });
+            });
+        }
+
+        else {
+            tokens.forEach(function(token) {
+                if (stopwords.words.indexOf(token) == -1)
+                    stemmedTokens.push(stemmer.stem(token));
+            });
+        }
         
         return stemmedTokens;
     };

--- a/spec/porter_stemmer_spec.js
+++ b/spec/porter_stemmer_spec.js
@@ -189,4 +189,8 @@ describe('porter_stemmer', function() {
 		var allCapitalStopwords = stopwords.words.join(' ').toUpperCase();
 		expect(allCapitalStopwords.tokenizeAndStem()).toEqual([]);
 	});
+
+	it('should tokenize and stem including stopwords', function() {
+		expect('My dog is very fun TO play with And another thing, he is A poodle.'.tokenizeAndStem(true)).toEqual(['my', 'dog', 'is', 'veri', 'fun', 'to', 'plai', 'with', 'and', 'anoth', 'thing', 'he', 'is', 'a', 'poodl']);
+	});
 });

--- a/spec/porter_stemmer_spec.js
+++ b/spec/porter_stemmer_spec.js
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 var stemmer = require('../lib/natural/stemmers/porter_stemmer');
+var stopwords = require('../lib/natural/util/stopwords');
 
 describe('porter_stemmer', function() {
 	it('should categorizeGroups', function() {
@@ -178,5 +179,14 @@ describe('porter_stemmer', function() {
 		stemmer.attach();
 		expect('scoring stinks'.tokenizeAndStem()).toEqual(['score', 'stink']);
 		expect('SCORING STINKS'.tokenizeAndStem()).toEqual(['score', 'stink']);
+	});
+
+	it('should tokenize and stem ignoring stopwords', function() {
+		expect('My dog is very fun TO play with And another thing, he is A poodle.'.tokenizeAndStem()).toEqual(['dog', 'fun', 'plai', 'thing', 'poodl']);
+	});
+
+	it('should tokenize and stem ignoring all capital stopwords', function() {
+		var allCapitalStopwords = stopwords.words.join(' ').toUpperCase();
+		expect(allCapitalStopwords.tokenizeAndStem()).toEqual([]);
 	});
 });


### PR DESCRIPTION
Currently, if the text that is passed into the `tokenizeAndStem` method contains non-lowercase stopwords, such as `'My'`, when we tokenize the string and check if the individual tokens exist in the stopwords array this check will evaluate to `false`, and the stopwords will be included in the output.

This change takes the input text and lowercases it prior to tokenizing, so all of the tokens can be tested directly against the stopwords and not included if we don't want to `keepStops`. Applicable specs included.