### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test": "NODE_PATH=. node_modules/jasmine-node/bin/jasmine-node spec/"
   },
+  "license": "MIT",
   "author": "Chris Umbel <chris@chrisumbel.com>",
   "keywords": [
     "natural",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/