### PR TITLE
fix commented closing bracket in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ The training process can be monitored by subscribing to the event `trainedWithDo
        *   total: 23 // There are 23 total documents being trained against
        *   index: 12 // The index/number of the document that's just been trained against
        *   doc: {...} // The document that has just been indexed
-       */ }
+       *  }
+       */ 
     });
 
 A classifier can also be persisted and recalled so you can reuse a training


### PR DESCRIPTION
moves the `}` inside the comment block, to make it even easier for those of us who blindly copy and paste :sunglasses: 