### PR TITLE
Increment nElement

### DIFF
--- a/lib/natural/util/bag.js
+++ b/lib/natural/util/bag.js
@@ -28,6 +28,7 @@ function Bag() {
 
 Bag.prototype.add = function(element) {
     this.dictionary.push(element);
+    this.nElement++;
     return this;
 };
 


### PR DESCRIPTION
Looks like nElement never gets incremented, yet it is used in the `isEmpty` function. As a result, `isEmpty` would always return true. Looks like there wasn't any test coverage for `Bag`. I'm happy to write some if desired.