### PR TITLE
Add multigram function

### DIFF
--- a/lib/natural/ngrams/ngrams.js
+++ b/lib/natural/ngrams/ngrams.js
@@ -42,6 +42,10 @@ exports.trigrams = function(sequence, startSymbol, endSymbol) {
     return ngrams(sequence, 3, startSymbol, endSymbol);
 }
 
+exports.multrigrams = function(sequence, n, startSymbol, endSymbol) {
+    return ngrams(sequence, n, startSymbol, endSymbol);
+}
+
 var ngrams = function(sequence, n, startSymbol, endSymbol) {
     var result = [];
     


### PR DESCRIPTION
Allows resizing the subsequence of n elements of a given sequence. 
For example, if you need to subsequences of 4 you can do this:
```
NGrams.multigrams('barcelona es un lugar fantastico', 4)
//[ [ 'Barcelona', 'es', 'un', 'lugar' ], [ 'es', 'un', 'lugar', 'fantastico' ] ]
```