### PR TITLE
Adds parallel multi-core training for classifiers

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -21,8 +21,10 @@ THE SOFTWARE.
 */
 
 var PorterStemmer = require('../stemmers/porter_stemmer'),
+Threads = require('webworker-threads'),
 util = require('util'),
-events = require('events');
+events = require('events')
+os = require('os');
 
 var Classifier = function(classifier, stemmer) {
     this.classifier = classifier;
@@ -96,6 +98,28 @@ function textToFeatures(observation) {
     return features;
 }
 
+function docsToFeatures(docs) {
+    var parsedDocs = [];
+    
+    for (var i = 0; i < docs.length; i++) {
+        var features = [];
+
+        for (var feature in FEATURES) {
+            if (docs[i].observation.indexOf(feature) > -1)
+                features.push(1);
+            else
+                features.push(0);
+        }
+
+        parsedDocs.push({
+            index: docs[i].index,
+            features: features
+        });
+    }
+    
+    return JSON.stringify(parsedDocs);
+}
+
 function train() {
     var totalDocs = this.docs.length;
     for(var i = this.lastAdded; i < totalDocs; i++) {
@@ -108,10 +132,111 @@ function train() {
     this.classifier.train();
 }
 
+function trainParallel(numThreads, callback) {
+    if (!callback) {
+        callback = numThreads;
+        numThreads = undefined;
+    }
+    
+    if (isNaN(numThreads)) {
+        numThreads = os.cpus().length;
+    }
+    
+    var totalDocs = this.docs.length;
+    var threadPool = Threads.createPool(numThreads);
+    var docFeatures = {};
+    var finished = 0;
+    var self = this;
+    
+    // Init pool; send the features array and the parsing function
+    threadPool.all.eval('var FEATURES = ' + JSON.stringify(this.features));
+    threadPool.all.eval(docsToFeatures);
+    
+    // Convert docs to observation objects
+    var obsDocs = [];
+    for (var i = this.lastAdded; i < totalDocs; i++) {
+        var observation = this.docs[i].text;
+        if (typeof observation === 'string')
+            observation = this.stemmer.tokenizeAndStem(observation);
+        obsDocs.push({
+            index: i,
+            observation: observation
+        });
+    }
+    
+    // Called when a batch completes processing
+    var onFeaturesResult = function(docs) {
+        setTimeout(function() {
+            self.events.emit('processedBatch', {
+                size: docs.length,
+                docs: totalDocs,
+                batches: numThreads,
+                index: finished
+            });
+        });
+        
+        for (var j = 0; j < docs.length; j++) {
+            docFeatures[docs[j].index] = docs[j].features;
+        }
+    };
+    
+    // Called when all batches finish processing
+    var onFinished = function(err) {
+        if (err) {
+            return callback(err);
+        }
+        
+        for (var j = self.lastAdded; j < totalDocs; j++) {
+            self.classifier.addExample(docFeatures[j], self.docs[j].label);
+            self.events.emit('trainedWithDocument', {
+                index: j,
+                total: totalDocs,
+                doc: self.docs[j]
+            });
+            self.lastAdded++;
+        }
+        
+        self.events.emit('doneTraining', true);
+        self.classifier.train();
+        
+        threadPool.destroy();
+        callback(null);
+    };
+    
+    // Split the docs and start processing
+    var batchSize = Math.ceil(obsDocs.length / numThreads);
+    var lastError;
+    
+    for (var i = 0; i < numThreads; i++) {
+        var batchDocs = obsDocs.slice(i * batchSize, (i+1) * batchSize);
+        var batchJson = JSON.stringify(batchDocs);
+        
+        threadPool.any.eval('docsToFeatures(' + batchJson + ')', function(err, docs) {
+            lastError = err || lastError;
+            finished++;
+            
+            if (docs) {
+                docs = JSON.parse(docs);
+                onFeaturesResult(docs);
+            }
+        
+            if (finished >= numThreads) {
+                onFinished(lastError);
+            }
+        });
+    }
+}
+
 function retrain() {
   this.classifier = new (this.classifier.constructor)();
   this.lastAdded = 0;
   this.train();
+}
+
+function retrainParallel(numThreads, callback) {
+  this.classifier = new (this.classifier.constructor)();
+  this.lastAdded = 0;
+  this.trainParallel(numThreads, callback);
 }
 
 function getClassifications(observation) {
@@ -144,7 +269,7 @@ function load(filename, callback) {
 
     fs.readFile(filename, 'utf8', function(err, data) {
         var classifier;
-          
+
         if(!err) {
             classifier = JSON.parse(data);
         }
@@ -157,7 +282,9 @@ function load(filename, callback) {
 Classifier.prototype.addDocument = addDocument;
 Classifier.prototype.removeDocument = removeDocument;
 Classifier.prototype.train = train;
+Classifier.prototype.trainParallel = trainParallel;
 Classifier.prototype.retrain = retrain;
+Classifier.prototype.retrainParallel = retrainParallel;
 Classifier.prototype.classify = classify;
 Classifier.prototype.textToFeatures = textToFeatures;
 Classifier.prototype.save = save;

--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -183,6 +183,7 @@ function trainParallel(numThreads, callback) {
     // Called when all batches finish processing
     var onFinished = function(err) {
         if (err) {
+            threadPool.destroy();
             return callback(err);
         }
         
@@ -224,6 +225,139 @@ function trainParallel(numThreads, callback) {
                 onFinished(lastError);
             }
         });
+    }
+}
+
+function trainParallelBatches(options) {
+    var numThreads = options && options.numThreads;
+    var batchSize = options && options.batchSize;
+    
+    if (isNaN(numThreads)) {
+        numThreads = os.cpus().length;
+    }
+    
+    if (isNaN(batchSize)) {
+        batchSize = 2500;
+    }
+    
+    var totalDocs = this.docs.length;
+    var threadPool = Threads.createPool(numThreads);
+    var docFeatures = {};
+    var finished = 0;
+    var self = this;
+    
+    var abort = false;
+    var onError = function(err) {
+        if (!err || abort) return;
+        abort = true;
+        threadPool.destroy(true);
+        self.events.emit('doneTrainingError', err);
+    };
+    
+    // Init pool; send the features array and the parsing function
+    var str = JSON.stringify(this.features);
+    console.log(str.length);
+    threadPool.all.eval('var FEATURES = ' + str + ';', onError);
+    threadPool.all.eval(docsToFeatures, onError);
+    
+    // Convert docs to observation objects
+    var obsDocs = [];
+    for (var i = this.lastAdded; i < totalDocs; i++) {
+        var observation = this.docs[i].text;
+        if (typeof observation === 'string')
+            observation = this.stemmer.tokenizeAndStem(observation);
+        obsDocs.push({
+            index: i,
+            observation: observation
+        });
+    }
+    
+    // Split the docs in batches
+    var obsBatches = [];
+    var i = 0;
+    while (true) {
+        var batch = obsDocs.slice(i * batchSize, (i+1) * batchSize);
+        if (!batch || !batch.length) break;
+        obsBatches.push(batch);
+        i++;
+    }
+    obsDocs = null;
+    self.events.emit('startedTraining', {
+        docs: totalDocs,
+        batches: obsBatches.length
+    });
+    
+    // Called when a batch completes processing
+    var onFeaturesResult = function(docs) {
+        self.events.emit('processedBatch', {
+            size: docs.length,
+            docs: totalDocs,
+            batches: obsBatches.length,
+            index: finished
+        });
+        
+        for (var j = 0; j < docs.length; j++) {
+            docFeatures[docs[j].index] = docs[j].features;
+        }
+    };
+    
+    // Called when all batches finish processing
+    var onFinished = function() {
+        threadPool.destroy(true);
+        abort = true;
+        
+        for (var j = self.lastAdded; j < totalDocs; j++) {
+            self.classifier.addExample(docFeatures[j], self.docs[j].label);
+            self.events.emit('trainedWithDocument', {
+                index: j,
+                total: totalDocs,
+                doc: self.docs[j]
+            });
+            self.lastAdded++;
+        }
+        
+        self.events.emit('doneTraining', true);
+        self.classifier.train();
+    };
+    
+    // Called to send the next batch to be processed
+    var batchIndex = 0;
+    var sendNext = function() {
+        if (abort) return;
+        if (batchIndex >= obsBatches.length) {
+            return;
+        }
+        
+        sendBatch(JSON.stringify(obsBatches[batchIndex]));
+        batchIndex++;
+    };
+    
+    // Called to send a batch of docs to the threads
+    var sendBatch = function(batchJson) {
+        if (abort) return;
+        threadPool.any.eval('docsToFeatures(' + batchJson + ');', function(err, docs) {
+            if (err) {
+                return onError(err);
+            }
+            
+            finished++;
+            
+            if (docs) {
+                docs = JSON.parse(docs);
+                setTimeout(onFeaturesResult.bind(null, docs));
+            }
+        
+            if (finished >= obsBatches.length) {
+                setTimeout(onFinished);
+            }
+            
+            setTimeout(sendNext);
+        });
+    };
+    
+    // Start processing
+    for (var i = 0; i < numThreads; i++) {
+        sendNext();
     }
 }
 
@@ -283,6 +417,7 @@ Classifier.prototype.addDocument = addDocument;
 Classifier.prototype.removeDocument = removeDocument;
 Classifier.prototype.train = train;
 Classifier.prototype.trainParallel = trainParallel;
+Classifier.prototype.trainParallelBatches = trainParallelBatches;
 Classifier.prototype.retrain = retrain;
 Classifier.prototype.retrainParallel = retrainParallel;
 Classifier.prototype.classify = classify;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "apparatus": ">= 0.0.9",
     "sylvester": ">= 0.0.12",
     "underscore": ">=1.3.1",
-    "webworker-threads": "^0.6.2"
+    "webworker-threads": ">=0.6.2"
   },
   "devDependencies": {
     "uubench": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "node": ">=0.4.10"
   },
   "dependencies": {
-    "sylvester": ">= 0.0.12",
     "apparatus": ">= 0.0.9",
-    "underscore": ">=1.3.1"
+    "sylvester": ">= 0.0.12",
+    "underscore": ">=1.3.1",
+    "webworker-threads": "^0.6.2"
   },
   "devDependencies": {
     "uubench": "0.0.x",

--- a/spec/bayes_classifier_spec.js
+++ b/spec/bayes_classifier_spec.js
@@ -39,6 +39,23 @@ describe('bayes classifier', function() {
             expect(classifier.classify(['read', 'thing'])).toBe('literature');
         });
 
+        it('should classify with parallel training', function() {
+            var classifier = new natural.BayesClassifier();
+
+            classifier.addDocument(['fix', 'box'], 'computing');
+            classifier.addDocument(['write', 'code'], 'computing');
+            classifier.addDocument(['script', 'code'], 'computing');
+            classifier.addDocument(['write', 'book'], 'literature');
+            classifier.addDocument(['read', 'book'], 'literature');
+            classifier.addDocument(['study', 'book'], 'literature');
+
+            classifier.trainParallel(2, function(err) {
+              expect(classifier.classify(['bug', 'code'])).toBe('computing');
+              expect(classifier.classify(['read', 'thing'])).toBe('literature');
+              asyncSpecDone();
+            });
+        });
+
         it('should provide all classification scores', function() {
             var classifier = new natural.BayesClassifier();
             classifier.addDocument(['fix', 'box'], 'computing');

--- a/spec/bayes_classifier_spec.js
+++ b/spec/bayes_classifier_spec.js
@@ -55,6 +55,25 @@ describe('bayes classifier', function() {
               asyncSpecDone();
             });
         });
+        
+        it('should classify with parallel batched training', function() {
+            var classifier = new natural.BayesClassifier();
+
+            classifier.addDocument(['fix', 'box'], 'computing');
+            classifier.addDocument(['write', 'code'], 'computing');
+            classifier.addDocument(['script', 'code'], 'computing');
+            classifier.addDocument(['write', 'book'], 'literature');
+            classifier.addDocument(['read', 'book'], 'literature');
+            classifier.addDocument(['study', 'book'], 'literature');
+            
+            classifier.events.on('doneTraining', function() {
+                expect(classifier.classify(['bug', 'code'])).toBe('computing');
+                expect(classifier.classify(['read', 'thing'])).toBe('literature');
+                asyncSpecDone();
+            });
+
+            classifier.trainParallelBatches({numThreads: 2, batchSize: 2});
+        });
 
         it('should provide all classification scores', function() {
             var classifier = new natural.BayesClassifier();


### PR DESCRIPTION
I used [webworker-threads](https://github.com/audreyt/node-webworker-threads) to create an asynchronous, multi-threaded `trainParallel` method for `Classifier`. I tested it with a small dataset and it worked well, however, the process went out of memory when I used a larger dataset:

```
<--- Last few GCs --->

  151133 ms: Mark-sweep 1364.5 (1456.0) -> 1358.3 (1456.0) MB, 255.4 / 0 ms [allocation failure] [GC in old space requested].
  151353 ms: Mark-sweep 1364.5 (1456.0) -> 1358.3 (1456.0) MB, 204.5 / 0 ms [allocation failure] [GC in old space requested].
  151620 ms: Mark-sweep 1364.5 (1456.0) -> 1358.3 (1456.0) MB, 249.3 / 0 ms [last resort gc].
  151874 ms: Mark-sweep 1358.3 (1456.0) -> 1358.3 (1456.0) MB, 254.1 / 0 ms [last resort gc].


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x256e14237399 <JS Object>
    1: parse [native json.js:~40] [pc=0x8e5f7117300] (this=0x256e142381b1 <a JSON with map 0x273c9a248c51>,r=0x2d0211004101 <Very long string[79148295]>,l=0x256e14204131 <undefined>)
    2: arguments adaptor frame: 1->2
    3: /* anonymous */ [/Users/aluxian/Projects/natural/lib/natural/classifiers/classifier.js:209] [pc=0x8e5f71d2335] (this=0x1fd6fb380be9 <JS Object>,err=0x256e14204111 <null>,...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
[1]    44567 abort      npm run sentiment-train -- --limit=20000
```

Here's how it works: the documents are split in n batches (n = number of threads, by default the number of CPUs). Each batch is sent to a thread from a pool to be processed. Exactly the same procedures are applied as for the sync method.

Any thoughts? What do you think about the implementation? How could I improve it? Any ideas about fixing/avoiding the OOM error?
