### PR TITLE
exports.Spellcheck missing

### DIFF
--- a/lib/natural/index.js
+++ b/lib/natural/index.js
@@ -65,6 +65,7 @@ exports.Trie = require('./trie/trie');
 exports.SentenceAnalyzer = require('./analyzers/sentence_analyzer');
 exports.stopwords = require('./util/stopwords').words;
 exports.ShortestPathTree = require('./util/shortest_path_tree');
+exports.Spellcheck = require('./spellcheck/spellcheck');
 exports.LongestPathTree = require('./util/longest_path_tree');
 exports.EdgeWeightedDigraph = require('./util/edge_weighted_digraph');
 exports.NGrams = require('./ngrams/ngrams');


### PR DESCRIPTION
I am working on an example demonstrating the Spellcheck functionality and noticed that the exports was missing from this file.  If this is not correct, please close and ignore!