### PR TITLE
Update WordNet section with renamed WNdb module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 natural
 =======
 
+[![NPM version](https://img.shields.io/npm/v/natural.svg)](https://www.npmjs.com/package/natural)
 [![Build Status](https://travis-ci.org/NaturalNode/natural.png?branch=master)](https://travis-ci.org/NaturalNode/natural)
 
 "Natural" is a general natural language facility for nodejs. Tokenizing,
@@ -885,16 +886,14 @@ WordNet
 
 One of the newest and most experimental features in natural is WordNet integration. Here's an
 example of using natural to look up definitions of the word node. To use the WordNet module,
-first install the WordNet database files using the [WNdb module](https://github.com/moos/WNdb):
+first install the WordNet database files using [wordnet-db](https://github.com/moos/wordnet-db):
 
-    npm install WNdb
-
-(For node < v0.6, please use 'npm install WNdb@3.0.0')
+    npm install wordnet-db
 
 Keep in mind that the WordNet integration is to be considered experimental at this point,
-and not production-ready. The API is also subject to change.
+and not production-ready. The API is also subject to change.  For an implementation with vastly increased performance, as well as a command-line interface, see [wordpos](https://github.com/moos/wordpos). 
 
-Here's an example of looking up definitions for the word, "node".
+Here's an example of looking up definitions for the word "node".
 
 ```javascript
 var wordnet = new natural.WordNet();

--- a/lib/natural/wordnet/wordnet.js
+++ b/lib/natural/wordnet/wordnet.js
@@ -137,9 +137,9 @@ function WordNet(dataDir) {
 
   if (!dataDir) {
     try {
-      var WNdb = require('WNdb');
+      var WNdb = require('wordnet-db');
     } catch(e) {
-      console.error("Please 'npm install WNdb' before using WordNet module or specify a dict directory.");
+      console.error("Please 'npm install wordnet-db' before using WordNet module or specify a dict directory.");
       throw e;
     }
     dataDir = WNdb.path;


### PR DESCRIPTION
Due to new npm naming rules, WNdb is going away.  I've updated the README with the new module name, added a link to wordpos, and an npm version badge.