### PR TITLE
Fixed bug in load methods for classifiers

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -47,7 +47,9 @@ function load(filename, stemmer, callback) {
         if (err) {
             callback(err);
         }
-        callback(err, restore(classifier, stemmer));
+        else {
+            callback(err, restore(classifier, stemmer));
+        }
     });
 }
 

--- a/lib/natural/classifiers/logistic_regression_classifier.js
+++ b/lib/natural/classifiers/logistic_regression_classifier.js
@@ -40,7 +40,12 @@ function restore(classifier, stemmer) {
 
 function load(filename, stemmer, callback) {
     Classifier.load(filename, function(err, classifier) {
-        callback(err, restore(classifier, stemmer));
+        if (err) {
+            callback(err);
+        }
+        else {
+            callback(err, restore(classifier, stemmer));
+        }
     });
 }
 

--- a/spec/bayes_classifier_spec.js
+++ b/spec/bayes_classifier_spec.js
@@ -158,6 +158,13 @@ describe('bayes classifier', function() {
             });
 	});
 
+        it('should only execute the callback once when failing to load a classifier', function() {
+            natural.BayesClassifier.load('nonexistant_bayes_classifier.json', null, function(err, newClassifier){
+              expect(err.code).toBe('ENOENT');
+              expect(newClassifier).toBe(undefined);
+              asyncSpecDone();
+            });
+        });
 
         it('should accept an optional smoothing parameter for the Bayesian estimates', function() {
             var defaultClassifier = new natural.BayesClassifier();

--- a/spec/logistic_regression_classifier_spec.js
+++ b/spec/logistic_regression_classifier_spec.js
@@ -119,4 +119,12 @@ describe('logistic regression', function() {
 	    });
 	});
     });
+
+    it('should only execute the callback once when failing to load a classifier', function() {
+        natural.LogisticRegressionClassifier.load('nonexistant_lr_classifier.json', null, function(err, newClassifier){
+          expect(err.code).toBe('ENOENT');
+          expect(newClassifier).toBe(undefined);
+          asyncSpecDone();
+        });
+    });
 });


### PR DESCRIPTION
In the case of the BayesClassifier, the callback was being called twice upon error, the second time erroneously calling `restore()` with an undefined `classifier`. LogisticRegressionClassifier was just calling `restore()` in all cases.