### PR TITLE
Adds Support for Hamming Distance

### DIFF
--- a/lib/natural/distance/hamming_distance.js
+++ b/lib/natural/distance/hamming_distance.js
@@ -1,0 +1,19 @@
+// Computes the Hamming distance between two string -- intrepreted from:
+// https://en.wikipedia.org/wiki/Hamming_distance
+// s1 is the first string to compare
+// s2 is the second string to compare
+function HammingDistance(s1, s2){
+	if (typeof(s1) != "string" || typeof(s2) != "string") return 0;
+	if (s1.length != s2.length) return 0;
+
+	s1 = s1.toLowerCase(), s2 = s2.toLowerCase();
+
+    var matches = 0; 
+    for (var i = 0; i < s1.length; i++){
+    	if s1[i] == s2[i]
+    		matches++;
+    }
+    return matches;	
+
+}
+module.exports = HammingDistance; 

--- a/lib/natural/index.js
+++ b/lib/natural/index.js
@@ -72,6 +72,7 @@ exports.EdgeWeightedDigraph = require('./util/edge_weighted_digraph');
 exports.NGrams = require('./ngrams/ngrams');
 exports.NGramsZH = require('./ngrams/ngrams_zh');
 exports.JaroWinklerDistance = require('./distance/jaro-winkler_distance');
+exports.HammingDistance = require('./distance/hamming_distance');
 exports.LevenshteinDistance = require('./distance/levenshtein_distance');
 exports.DiceCoefficient = require('./distance/dice_coefficient');
 exports.normalize = require('./normalizers/normalizer').normalize_tokens;


### PR DESCRIPTION
Hamming Distance is a really basic algorithm for string distance comparison.

It's often taught as a precursor to more advanced algs. It's pretty basic code, but I figured NaturalNode might as well support it. I also thought it might make a good code snippet to make sure I'm not missing anything glaring from a code-style perspective - I'd like to work on NaturalNode in the future. 

Let me know what you think!
