### PR TITLE
Simplified creating a tagger object

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,22 +967,19 @@ algorithm. Transformation rules are specified in external files.
 
 ### Usage
 ```javascript
-var Tagger = require("./lib/natural").BrillPOSTagger;
+var natural = require("./lib/natural");
 
 var base_folder = "some_path/lib/natural/brill_pos_tagger";
-var rules_file = base_folder + "/data/tr_from_posjs.txt";
-var lexicon_file = base_folder + "/data/lexicon_from_posjs.json";
-var default_category = 'N';
+var rulesFilename = base_folder + "/data/tr_from_posjs.txt";
+var lexiconFilename = base_folder + "/data/lexicon_from_posjs.json";
+var defaultCategory = 'N';
 
-var tagger = new Tagger(lexicon_file, rules_file, default_category, function(error) {
-  if (error) {
-    console.log(error);
-  }
-  else {
-    var sentence = ["I", "see", "the", "man", "with", "the", "telescope"];
-    console.log(JSON.stringify(tagger.tag(sentence)));
-  }
-});
+var lexicon = new natural.Lexicon(lexiconFilename, defaultCategory);
+var rules = new natural.Ruleset(rulesFilename);
+var tagger = new natural.BrillPOSTagger(lexicon, rules);
+
+var sentence = ["I", "see", "the", "man", "with", "the", "telescope"];
+console.log(JSON.stringify(tagger.tag(sentence)));
 ```
 
 ### Lexicon

--- a/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
+++ b/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
@@ -31,8 +31,6 @@ logger.setLevel('WARN');
 Brill_POS_Tagger.prototype.tag = function(sentence) {
   var taggedSentence = new Array(sentence.length);
   
-  // Initialise taggedSentence
-  // for (var i = 0, size = sentence.length; i < size; i++) {
   var that = this;
   sentence.forEach(function(word, index) {
     taggedSentence[index] = [];
@@ -40,20 +38,6 @@ Brill_POS_Tagger.prototype.tag = function(sentence) {
     var categories = that.lexicon.tagWord(word);
     taggedSentence[index][1] = categories[0];
   });
-    /*
-    var ss = this.lexicon[sentence[i]];
-    if (!ss) {
-      ss = this.lexicon[sentence[i].toLowerCase()];
-    }
-    tagged_sentence[i] = [];
-    tagged_sentence[i][0] = sentence[i];
-    if (!ss) { // If not found assign default_category
-      tagged_sentence[i][1] = this.default_category;
-    }
-    else {
-      tagged_sentence[i][1] = ss[0];
-    }
-  }*/
 
   // Apply transformation rules
   for (var i = 0, size = sentence.length; i < size; i++) {
@@ -62,60 +46,6 @@ Brill_POS_Tagger.prototype.tag = function(sentence) {
     });
   }
   return(taggedSentence);
-};
-
-Brill_POS_Tagger.prototype.parse_lexicon = function(data) {
-  var that = this;
-  // Split into an array of non-empty lines
-  var arrayOfLines = data.match(/[^\r\n]+/g);
-  this.lexicon = {};
-  arrayOfLines.forEach(function(line) {
-    // Split line by whitespace
-    var elements = line.trim().split(/\s+/);
-    if (elements.length > 0) {
-      that.lexicon[elements[0]] = elements.slice(1);
-    }
-  });
-};
-
-Brill_POS_Tagger.prototype.read_lexicon = function(lexicon_file,callback) {
-  var that = this;
-  
-  // Read lexicon
-  fs.readFile(lexicon_file, 'utf8', function (error, data) {
-    if (error) {
-      logger.error(error);
-      callback(error);
-    }
-    else {
-      if (data[0] === "{") {
-        // Lexicon is in JSON format
-        that.lexicon = JSON.parse(data);
-        callback();
-      }
-      else {
-        // Lexicon is plain text
-        that.parse_lexicon(data);
-        callback();
-      }
-      logger.debug('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
-    }
-  });
-};
-
-Brill_POS_Tagger.prototype.readTransformationRules = function(rulesFile) {
-  var that = this;
-
-  // Read transformation rules
-  try {
-    var data = fs.readFileSync(rulesFile, 'utf8');
-    that.transformation_rules = TF_Parser.parse(data);
-    logger.debug(that.transformation_rules);
-    logger.debug('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + that.transformation_rules.length);
-  }
-  catch(error) {
-    logger.error(error);
-  }
 };
 
 function Brill_POS_Tagger(lexicon, ruleSet) {

--- a/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
+++ b/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
@@ -1,6 +1,6 @@
 /*
     Brill's POS Tagger
-    Copyright (C) 2015 Hugo W.L. ter Doest
+    Copyright (C) 2016 Hugo W.L. ter Doest
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,10 +29,18 @@ logger.setLevel('WARN');
 // Returns an array of tagged words; a tagged words is an array consisting of
 // the word itself followed by its lexical category
 Brill_POS_Tagger.prototype.tag = function(sentence) {
-  var tagged_sentence = new Array(sentence.length);
+  var taggedSentence = new Array(sentence.length);
   
-  // Initialise result
-  for (var i = 0, size = sentence.length; i < size; i++) {
+  // Initialise taggedSentence
+  // for (var i = 0, size = sentence.length; i < size; i++) {
+  var that = this;
+  sentence.forEach(function(word, index) {
+    taggedSentence[index] = [];
+    taggedSentence[index][0] = word;
+    var categories = that.lexicon.tagWord(word);
+    taggedSentence[index][1] = categories[0];
+  });
+    /*
     var ss = this.lexicon[sentence[i]];
     if (!ss) {
       ss = this.lexicon[sentence[i].toLowerCase()];
@@ -45,14 +53,15 @@ Brill_POS_Tagger.prototype.tag = function(sentence) {
     else {
       tagged_sentence[i][1] = ss[0];
     }
-  }
+  }*/
+
   // Apply transformation rules
   for (var i = 0, size = sentence.length; i < size; i++) {
-    this.transformation_rules.forEach(function(rule) {
-      rule.apply(tagged_sentence, i);
+    this.ruleSet.rules.forEach(function(rule) {
+      rule.apply(taggedSentence, i);
     });
   }
-  return(tagged_sentence);
+  return(taggedSentence);
 };
 
 Brill_POS_Tagger.prototype.parse_lexicon = function(data) {
@@ -94,43 +103,24 @@ Brill_POS_Tagger.prototype.read_lexicon = function(lexicon_file,callback) {
   });
 };
 
-Brill_POS_Tagger.prototype.read_transformation_rules = function(rules_file, callback) {
+Brill_POS_Tagger.prototype.readTransformationRules = function(rulesFile) {
   var that = this;
 
   // Read transformation rules
-  fs.readFile(rules_file, 'utf8', function (err, data) {
-    if (err) {
-      logger.error(error);
-      callback(err);
-    }
-    else {
-      that.transformation_rules = TF_Parser.parse(data);
-      logger.debug(that.transformation_rules);
-      logger.debug('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + that.transformation_rules.length);
-      callback();
-    }
-  });
+  try {
+    var data = fs.readFileSync(rulesFile, 'utf8');
+    that.transformation_rules = TF_Parser.parse(data);
+    logger.debug(that.transformation_rules);
+    logger.debug('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + that.transformation_rules.length);
+  }
+  catch(error) {
+    logger.error(error);
+  }
 };
 
-function Brill_POS_Tagger(lexicon_file, rules_file, default_category, callback) {
-  var that = this;
-  
-  this.default_category = default_category;
-  this.read_lexicon(lexicon_file, function(error) {
-    if (error) {
-      callback(error);
-    }
-    else {
-      that.read_transformation_rules(rules_file, function(error) {
-        if (error) {
-          callback(error);
-        }
-        else {
-          callback();
-        }
-      });
-    }
-  });
+function Brill_POS_Tagger(lexicon, ruleSet) {
+  this.lexicon = lexicon;
+  this.ruleSet = ruleSet;
 }
 
 module.exports = Brill_POS_Tagger;

--- a/lib/natural/brill_pos_tagger/lib/Lexicon.js
+++ b/lib/natural/brill_pos_tagger/lib/Lexicon.js
@@ -1,19 +1,19 @@
 /*
- Lexicon class
- Copyright (C) 2016 Hugo W.L. ter Doest
+   Lexicon class
+   Copyright (C) 2016 Hugo W.L. ter Doest
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 var fs = require('fs');

--- a/lib/natural/brill_pos_tagger/lib/Lexicon.js
+++ b/lib/natural/brill_pos_tagger/lib/Lexicon.js
@@ -1,0 +1,74 @@
+/*
+ Lexicon class
+ Copyright (C) 2016 Hugo W.L. ter Doest
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var fs = require('fs');
+var log4js = require('log4js');
+var logger = log4js.getLogger();
+
+// Parses a lexicon in JSON or text format
+function Lexicon(filename, defaultCategory) {
+  this.defaultCategory = defaultCategory;
+  var that = this;
+
+  // Read lexicon
+  try {
+    var data = fs.readFileSync(filename, 'utf8');
+    if (data[0] === "{") {
+      // Lexicon is in JSON format
+      that.lexicon = JSON.parse(data);
+    }
+    else {
+      // Lexicon is plain text
+      that.parseLexicon(data);
+    }
+    logger.debug('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
+  }
+  catch(error) {
+    logger.error(error);
+  }
+}
+
+// Parses a lexicon in text format: word cat1 cat2 ... catn
+Lexicon.prototype.parseLexicon = function(data) {
+  // Split into an array of non-empty lines
+  var arrayOfLines = data.match(/[^\r\n]+/g);
+  this.lexicon = {};
+  var that = this;
+  arrayOfLines.forEach(function(line) {
+    // Split line by whitespace
+    var elements = line.trim().split(/\s+/);
+    if (elements.length > 0) {
+      that.lexicon[elements[0]] = elements.slice(1);
+    }
+  });
+};
+
+// Returns a list of categories for word
+Lexicon.prototype.tagWord = function(word) {
+  var categories = this.lexicon[word];
+  if (!categories) {
+    categories = this.lexicon[word.toLowerCase()];
+  }
+  if (!categories) {
+    // If not found assign default_category
+    categories = [this.defaultCategory];
+  }
+  return(categories);
+};
+
+module.exports = Lexicon;

--- a/lib/natural/brill_pos_tagger/lib/RuleSet.js
+++ b/lib/natural/brill_pos_tagger/lib/RuleSet.js
@@ -1,0 +1,39 @@
+/*
+   Set of transformation rules
+   Copyright (C) 2016 Hugo W.L. ter Doest
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var log4js = require('log4js');
+var logger = log4js.getLogger();
+var fs = require("fs");
+var TF_Parser = require('./TF_Parser');
+
+function RuleSet(filename) {
+  var that = this;
+
+  // Read transformation rules
+  try {
+    var data = fs.readFileSync(filename, 'utf8');
+    this.rules = TF_Parser.parse(data);
+    logger.debug(this.rules);
+    logger.debug('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + this.rules.length);
+  }
+  catch(error) {
+    logger.error(error);
+  }
+}
+
+module.exports = RuleSet;

--- a/lib/natural/index.js
+++ b/lib/natural/index.js
@@ -76,3 +76,7 @@ exports.normalize_ja = require('./normalizers/normalizer_ja').normalize_ja;
 exports.removeDiacritics = require('./normalizers/remove_diacritics');
 exports.transliterate_ja = require('./transliterators/ja');
 exports.BrillPOSTagger = require('./brill_pos_tagger/lib/Brill_POS_Tagger');
+exports.Lexicon = require('./brill_pos_tagger/lib/Lexicon');
+exports.RuleSet = require('./brill_pos_tagger/lib/RuleSet');
+
+

--- a/spec/brill_pos_tagger_spec.js
+++ b/spec/brill_pos_tagger_spec.js
@@ -35,11 +35,13 @@ var du_ex_volkskrant_article = base_folder_test_data + '/Volkskrant-20150205-Kno
 
 
 describe('Brill\'s POS Tagger', function() {
-  var brill_pos_tagger;
-  it('should initialise correctly with tagging rules for English', function(done) {
-    brill_pos_tagger = new natural.BrillPOSTagger(en_lexicon_file, en_rules_file, 'NN', function(error) {
-      done();
-    });
+  var brill_pos_tagger = null;
+  var lexicon = null;
+  var ruleSet = null;
+  it('should initialise correctly with tagging rules for English', function() {
+    lexicon = new natural.Lexicon(en_lexicon_file, 'NN');
+    var ruleSet = new natural.RuleSet(en_rules_file);
+    brill_pos_tagger = new natural.BrillPOSTagger(lexicon, ruleSet);
   });
 
   var sentences;
@@ -68,10 +70,10 @@ describe('Brill\'s POS Tagger', function() {
     });
   });
   
-  it('should initialise correctly with tagging rules for Dutch', function(done) {
-    brill_pos_tagger = new natural.BrillPOSTagger(du_lexicon_file, du_rules_file, 'N', function(error) {
-      done();
-    });
+  it('should initialise correctly with tagging rules for Dutch', function() {
+    lexicon = new natural.Lexicon(du_lexicon_file, 'N');
+    var ruleSet = new natural.RuleSet(du_rules_file);
+    brill_pos_tagger = new natural.BrillPOSTagger(lexicon, ruleSet);
   });
   
   it('should correctly read a Volkskrant article about the ECB', function(done) {

--- a/spec/porter_stemmer_it_spec.js
+++ b/spec/porter_stemmer_it_spec.js
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-var stemmer = require('lib/natural/stemmers/porter_stemmer_it');
+var stemmer = require('../lib/natural/stemmers/porter_stemmer_it');
 var fs = require('fs');
 
 describe('porter_stemmer_it', function() {


### PR DESCRIPTION
Creating a tagger is now done as follows:

```
var lexicon = new Lexicon(lexiconFilename, defaultCategory);
var rules = new Ruleset(rulesFilename);
var tagger = new BrillPOSTagger(lexicon, rules);
```

It is no longer asynchronous, and you can pass in your own implementation of a lexicon object as long as it offers a tagWord method that accepts a string and returns an array of categories. 