### PR TITLE
Remove log4js dependency to allow for Webpack client compilation

### DIFF
--- a/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
+++ b/lib/natural/brill_pos_tagger/lib/Brill_POS_Tagger.js
@@ -16,14 +16,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var log4js = require('log4js');
-var logger = log4js.getLogger();
-
 var fs = require("fs");
 
 var TF_Parser = require('./TF_Parser');
-
-logger.setLevel('WARN');
 
 // Tags a sentence, sentence is an array of words
 // Returns an array of tagged words; a tagged words is an array consisting of

--- a/lib/natural/brill_pos_tagger/lib/Lexicon.js
+++ b/lib/natural/brill_pos_tagger/lib/Lexicon.js
@@ -34,7 +34,7 @@ function Lexicon(filename, defaultCategory) {
       // Lexicon is plain text
       that.parseLexicon(data);
     }
-    console.log('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
+    // console.log('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
   }
   catch(error) {
     console.error(error);

--- a/lib/natural/brill_pos_tagger/lib/Lexicon.js
+++ b/lib/natural/brill_pos_tagger/lib/Lexicon.js
@@ -17,8 +17,6 @@
 */
 
 var fs = require('fs');
-var log4js = require('log4js');
-var logger = log4js.getLogger();
 
 // Parses a lexicon in JSON or text format
 function Lexicon(filename, defaultCategory) {
@@ -36,10 +34,10 @@ function Lexicon(filename, defaultCategory) {
       // Lexicon is plain text
       that.parseLexicon(data);
     }
-    logger.debug('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
+    console.log('Brill_POS_Tagger.read_lexicon: number of lexicon entries read: ' + Object.keys(that.lexicon).length);
   }
   catch(error) {
-    logger.error(error);
+    console.error(error);
   }
 }
 

--- a/lib/natural/brill_pos_tagger/lib/Predicate.js
+++ b/lib/natural/brill_pos_tagger/lib/Predicate.js
@@ -395,8 +395,8 @@ function Predicate(name, parameter1, parameter2) {
     this.predicate = default_transformation_rule;
     console.warn('Predicate constructor: predicate not found: ' + name + '; using default');
   }
-  console.log(this.name);
-  console.log(this.function);
+  // console.log(this.name);
+  // console.log(this.function);
 }
 
 Predicate.prototype.evaluate = function(tagged_sentence, position) {

--- a/lib/natural/brill_pos_tagger/lib/Predicate.js
+++ b/lib/natural/brill_pos_tagger/lib/Predicate.js
@@ -16,10 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var log4js = require('log4js');
-var logger = log4js.getLogger();
-logger.setLevel('WARN');
-
 var predicates = {
     // Predicates as used in the English rules in data/English/tr_from_posjs.txt
     "NEXT-TAG": next_tag_is,
@@ -397,10 +393,10 @@ function Predicate(name, parameter1, parameter2) {
   this.function = predicates[name];
   if (!this.function) {
     this.predicate = default_transformation_rule;
-    logger.warn('Predicate constructor: predicate not found: ' + name + '; using default');
+    console.warn('Predicate constructor: predicate not found: ' + name + '; using default');
   }
-  logger.debug(this.name);
-  logger.debug(this.function);
+  console.log(this.name);
+  console.log(this.function);
 }
 
 Predicate.prototype.evaluate = function(tagged_sentence, position) {

--- a/lib/natural/brill_pos_tagger/lib/RuleSet.js
+++ b/lib/natural/brill_pos_tagger/lib/RuleSet.js
@@ -16,8 +16,6 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var log4js = require('log4js');
-var logger = log4js.getLogger();
 var fs = require("fs");
 var TF_Parser = require('./TF_Parser');
 
@@ -28,11 +26,11 @@ function RuleSet(filename) {
   try {
     var data = fs.readFileSync(filename, 'utf8');
     this.rules = TF_Parser.parse(data);
-    logger.debug(this.rules);
-    logger.debug('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + this.rules.length);
+    console.log(this.rules);
+    console.log('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + this.rules.length);
   }
   catch(error) {
-    logger.error(error);
+    console.error(error);
   }
 }
 

--- a/lib/natural/brill_pos_tagger/lib/RuleSet.js
+++ b/lib/natural/brill_pos_tagger/lib/RuleSet.js
@@ -26,8 +26,8 @@ function RuleSet(filename) {
   try {
     var data = fs.readFileSync(filename, 'utf8');
     this.rules = TF_Parser.parse(data);
-    console.log(this.rules);
-    console.log('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + this.rules.length);
+    // console.log(this.rules);
+    // console.log('Brill_POS_Tagger.read_transformation_rules: number of transformation rules read: ' + this.rules.length);
   }
   catch(error) {
     console.error(error);

--- a/lib/natural/brill_pos_tagger/lib/TransformationRule.js
+++ b/lib/natural/brill_pos_tagger/lib/TransformationRule.js
@@ -25,7 +25,7 @@ function TransformationRule(c1, c2, predicate, parameter1, parameter2) {
   this.predicate = new Predicate(predicate, parameter1, parameter2);
   this.old_category = c1;
   this.new_category = c2;
-  console.log('TransformationRule constructor: ' + this.literal);
+  // console.log('TransformationRule constructor: ' + this.literal);
 }
 
 TransformationRule.prototype.apply = function(tagged_sentence, position) {
@@ -33,9 +33,9 @@ TransformationRule.prototype.apply = function(tagged_sentence, position) {
       (this.old_category === category_wild_card)) {
     if (this.predicate.evaluate(tagged_sentence, position)) {
       tagged_sentence[position][1] = this.new_category;
-      console.log('TransformationRule.apply: changed category ' + 
-                   this.old_category + ' to ' + this.new_category +
-                   ' at position ' + position);
+      // console.log('TransformationRule.apply: changed category ' + 
+      //              this.old_category + ' to ' + this.new_category +
+      //              ' at position ' + position);
     }
   }
 };

--- a/lib/natural/brill_pos_tagger/lib/TransformationRule.js
+++ b/lib/natural/brill_pos_tagger/lib/TransformationRule.js
@@ -16,12 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var log4js = require('log4js');
-var logger = log4js.getLogger();
-
 var Predicate = require("./Predicate");
-
-logger.setLevel('ERROR');
 
 var category_wild_card = "*";
 
@@ -30,7 +25,7 @@ function TransformationRule(c1, c2, predicate, parameter1, parameter2) {
   this.predicate = new Predicate(predicate, parameter1, parameter2);
   this.old_category = c1;
   this.new_category = c2;
-  logger.debug('TransformationRule constructor: ' + this.literal);
+  console.log('TransformationRule constructor: ' + this.literal);
 }
 
 TransformationRule.prototype.apply = function(tagged_sentence, position) {
@@ -38,7 +33,7 @@ TransformationRule.prototype.apply = function(tagged_sentence, position) {
       (this.old_category === category_wild_card)) {
     if (this.predicate.evaluate(tagged_sentence, position)) {
       tagged_sentence[position][1] = this.new_category;
-      logger.debug('TransformationRule.apply: changed category ' + 
+      console.log('TransformationRule.apply: changed category ' + 
                    this.old_category + ' to ' + this.new_category +
                    ' at position ' + position);
     }

--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
     "node": ">=0.4.10"
   },
   "dependencies": {
-    "sylvester": ">= 0.0.12",
     "apparatus": ">= 0.0.9",
-    "underscore": ">=1.3.1",
-    "log4js": "*"
+    "sylvester": ">= 0.0.12",
+    "underscore": ">=1.3.1"
   },
   "devDependencies": {
-    "uubench": "0.0.x",
-    "jasmine-node": "~1.13.1"
+    "jasmine-node": "~1.13.1",
+    "uubench": "0.0.x"
   },
   "scripts": {
     "test": "NODE_PATH=. node_modules/jasmine-node/bin/jasmine-node spec/"


### PR DESCRIPTION
This PR fixes #320.

As you can see in the commits, it is a very simple change, but it will make the code a lot more consistent. The log4js dependency was only ever used within the Brill POS Tagger and not anywhere else in our code base.

### Results of merging this PR

By making this change, we make the code inside Brill POS Tagger not only lighter, but also more consistent with the rest of the project.

And better yet, it means we can start using Natural on the frontend without errors being caused by log4js.

### Testing

`npm test` was run before and after the changes in this PR and there has been no change whatsoever. In other words, this PR does not cause any new tests to fail.