### PR TITLE
Make webworker-threads optional

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -21,10 +21,22 @@ THE SOFTWARE.
 */
 
 var PorterStemmer = require('../stemmers/porter_stemmer'),
-Threads = require('webworker-threads'),
 util = require('util'),
 events = require('events')
 os = require('os');
+
+try {
+    var Threads = require('webworker-threads');
+} catch (e) {
+    // Since webworker-threads are optional, only thow if the module is found
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
+}
+
+function checkThreadSupport() {
+    if (typeof Threads === 'undefined') {
+        throw new Error('parallel classification requires the optional dependency webworker-threads');
+    }
+}
 
 var Classifier = function(classifier, stemmer) {
     this.classifier = classifier;
@@ -142,6 +154,8 @@ function train() {
 }
 
 function trainParallel(numThreads, callback) {
+    checkThreadSupport();
+
     if (!callback) {
         callback = numThreads;
         numThreads = undefined;
@@ -238,6 +252,8 @@ function trainParallel(numThreads, callback) {
 }
 
 function trainParallelBatches(options) {
+    checkThreadSupport();
+
     var numThreads = options && options.numThreads;
     var batchSize = options && options.batchSize;
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
   "dependencies": {
     "apparatus": ">= 0.0.9",
     "sylvester": ">= 0.0.12",
-    "underscore": ">=1.3.1",
-    "webworker-threads": ">=0.6.2"
+    "underscore": ">=1.3.1"
   },
   "devDependencies": {
-    "uubench": "0.0.x",
+    "jasmine-node": "~1.13.1",
+    "proxyquire": "^1.8.0",
     "sinon": "^1.12.2",
-    "jasmine-node": "~1.13.1"
+    "uubench": "0.0.x"
+  },
+  "optionalDependencies": {
+    "webworker-threads": ">=0.6.2"
   },
   "scripts": {
     "test": "NODE_PATH=. node_modules/jasmine-node/bin/jasmine-node spec/"

--- a/spec/missing_webworker_threads_spec.js
+++ b/spec/missing_webworker_threads_spec.js
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2017, Ryan Witt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+var sinon = require('sinon');
+var proxyquire = require('proxyquire');
+var baseClassifier = proxyquire('lib/natural/classifiers/classifier.js', {
+    'webworker-threads': null
+});
+
+describe('missing webworker-threads', function() {
+    describe('classifier', function() {
+        it('should refuse to classify with parallel training', function() {
+            var classifier = new baseClassifier();
+            classifier.addDocument(['foo', 'bar'], 'baz');
+            expect(function() {
+                classifier.trainParallel(2)
+            }).toThrow(new Error('parallel classification requires the optional dependency webworker-threads'));
+        });
+
+        it('should refuse to classify with parallel batched training', function() {
+            var classifier = new baseClassifier();
+            classifier.addDocument(['foo', 'bar'], 'baz');
+            classifier.addDocument(['fizz', 'buzz'], 'boo');
+            expect(function() {
+                classifier.trainParallelBatches({numThreads: 2, batchSize: 2});
+            }).toThrow(new Error('parallel classification requires the optional dependency webworker-threads'));
+        });
+    });
+});


### PR DESCRIPTION
This is intended to resolve #345.

`webworker-threads` is now an optionalDependency, meaning npm will attempt to install it, but not fail if it does not succeed.

The `trainParallel`,`trainParallelBatches` and functions that call them (only `retrainParallel` in this lib) will now throw a runtime error prompting the user to install `webworker-threads`.

The tests add `proxyquire` as a devDependency to simulate the absence of the `webworker-threads` module.