### PR TITLE
Levenshtein search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Aside from this README, the only documentation is [this DZone article](http://ww
 * [Installation](#installation)
 * [Tokenizers](#tokenizers)
 * [String Distance](#string-distance)
+* [Approximate String Matching](#approximate-string-matching)
 * [Stemmers](#stemmers)
 * [Classifiers](#classifiers)
 * [Phonetics](#phonetics)
@@ -142,6 +143,23 @@ Output:
 ```javascript
 1
 0
+```
+
+## Approximate String Matching
+Currently matching is supported via the Levenshtein algorithm.
+
+```javascript
+var natural = require('natural');
+var source = 'The RainCoat BookStore';
+var target = 'All the best books are here at the Rain Coats Book Store';
+
+console.log(natural.LevenshteinDistance(source, target, {search: true}));
+```
+
+Output:
+
+```javascript
+{ substring: 'the Rain Coats Book Store', distance: 4 }
 ```
 
 ## Stemmers

--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -29,6 +29,8 @@ THE SOFTWARE.
  * Algorithm based from Speech and Language Processing - Daniel Jurafsky and James H. Martin.
  */
 
+var _ = require('underscore');
+
 function LevenshteinDistance (source, target, options) {
     options = options || {};
     if(isNaN(options.insertion_cost)) options.insertion_cost = 1;
@@ -37,32 +39,45 @@ function LevenshteinDistance (source, target, options) {
 
     var sourceLength = source.length;
     var targetLength = target.length;
-    var distanceMatrix = [[0]];
+    var distanceMatrix = [[{cost: 0}]];
 
     for (var row =  1; row <= sourceLength; row++) {
         distanceMatrix[row] = [];
-        distanceMatrix[row][0] = distanceMatrix[row-1][0] + options.deletion_cost;
+        distanceMatrix[row][0] = {cost: distanceMatrix[row-1][0].cost + options.deletion_cost};
     }
 
     for (var column = 1; column <= targetLength; column++) {
-        distanceMatrix[0][column] = distanceMatrix[0][column-1] + options.insertion_cost;
+        if (options.search) {
+          distanceMatrix[0][column] = {cost: 0};
+        } else {
+          distanceMatrix[0][column] = {cost: distanceMatrix[0][column-1].cost + options.insertion_cost};
+        }
     }
 
     for (var row = 1; row <= sourceLength; row++) {
         for (var column = 1; column <= targetLength; column++) {
-            var costToInsert = distanceMatrix[row][column-1] + options.insertion_cost;
-            var costToDelete = distanceMatrix[row-1][column] + options.deletion_cost;
+            var costToInsert = distanceMatrix[row][column-1].cost + options.insertion_cost;
+            var costToDelete = distanceMatrix[row-1][column].cost + options.deletion_cost;
 
             var sourceElement = source[row-1];
             var targetElement = target[column-1];
-            var costToSubstitute = distanceMatrix[row-1][column-1];
+            var costToSubstitute = distanceMatrix[row-1][column-1].cost;
             if (sourceElement !== targetElement) {
                 costToSubstitute = costToSubstitute + options.substitution_cost;
             }
-            distanceMatrix[row][column] = Math.min(costToInsert, costToDelete, costToSubstitute);
+
+            var possibleParents = [
+              {cost: costToInsert, coordinates: {row: row, column: column-1}},
+              {cost: costToDelete, coordinates: {row: row-1, column: column}},
+              {cost: costToSubstitute, coordinates: {row: row-1, column: column-1}}
+            ];
+
+            var minCostParent = _.min(possibleParents, function(p) { return p.cost; });
+
+            distanceMatrix[row][column] = {cost: minCostParent.cost, parentCell: minCostParent.coordinates};
         }
     }
-    return distanceMatrix[sourceLength][targetLength];
+    return distanceMatrix[sourceLength][targetLength].cost;
 }
 
 module.exports = LevenshteinDistance;

--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -31,20 +31,26 @@ THE SOFTWARE.
 
 var _ = require('underscore');
 
+// Walk the path back from the matchEnd to the beginning of the match.
+// Do this by traversing the distanceMatrix as you would a linked list,
+// following going from cell child to parent until reach row 0.
 function _getMatchStart(distanceMatrix, matchEnd, sourceLength) {
   var row = sourceLength;
   var column = matchEnd;
   var tmpRow;
   var tmpColumn;
 
-  while(typeof distanceMatrix[row][column].parentCell !== 'undefined') {
+  // match will be empty string
+  if (matchEnd === 0) { return 0; }
+
+  while(row > 1 && column > 1) {
    tmpRow = row;
    tmpColumn = column;
    row = distanceMatrix[tmpRow][tmpColumn].parentCell.row;
    column = distanceMatrix[tmpRow][tmpColumn].parentCell.column;
   }
 
-  return column;
+  return column-1;
 }
 
 function getMinCostSubstring(distanceMatrix, source, target) {
@@ -53,7 +59,9 @@ function getMinCostSubstring(distanceMatrix, source, target) {
   var minDistance = sourceLength + targetLength;
   var matchEnd = targetLength;
 
-  for (var column = 1; column <= targetLength; column++) {
+  // Find minimum value in last row of the cost matrix. This cell marks the
+  // end of the match string.
+  for (var column = 0; column <= targetLength; column++) {
     if (minDistance > distanceMatrix[sourceLength][column].cost) {
       minDistance = distanceMatrix[sourceLength][column].cost;
       matchEnd = column;
@@ -74,7 +82,7 @@ function LevenshteinDistance (source, target, options) {
 
     var sourceLength = source.length;
     var targetLength = target.length;
-    var distanceMatrix = [[{cost: 0}]];
+    var distanceMatrix = [[{cost: 0}]]; //the root, has no parent cell
 
     for (var row =  1; row <= sourceLength; row++) {
         distanceMatrix[row] = [];

--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -37,14 +37,14 @@ function _getMatchStart(distanceMatrix, matchEnd, sourceLength) {
   var tmpRow;
   var tmpColumn;
 
-  while(row > 1) {
+  while(typeof distanceMatrix[row][column].parentCell !== 'undefined') {
    tmpRow = row;
    tmpColumn = column;
    row = distanceMatrix[tmpRow][tmpColumn].parentCell.row;
    column = distanceMatrix[tmpRow][tmpColumn].parentCell.column;
   }
 
-  return column-1;
+  return column;
 }
 
 function getMinCostSubstring(distanceMatrix, source, target) {
@@ -78,14 +78,14 @@ function LevenshteinDistance (source, target, options) {
 
     for (var row =  1; row <= sourceLength; row++) {
         distanceMatrix[row] = [];
-        distanceMatrix[row][0] = {cost: distanceMatrix[row-1][0].cost + options.deletion_cost};
+        distanceMatrix[row][0] = {cost: distanceMatrix[row-1][0].cost + options.deletion_cost, parentCell: {row: row-1, column: 0}};
     }
 
     for (var column = 1; column <= targetLength; column++) {
         if (options.search) {
           distanceMatrix[0][column] = {cost: 0};
         } else {
-          distanceMatrix[0][column] = {cost: distanceMatrix[0][column-1].cost + options.insertion_cost};
+          distanceMatrix[0][column] = {cost: distanceMatrix[0][column-1].cost + options.insertion_cost, parentCell: {row: 0, column: column-1}};
         }
     }
 

--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -31,11 +31,46 @@ THE SOFTWARE.
 
 var _ = require('underscore');
 
+function _getMatchStart(distanceMatrix, matchEnd, sourceLength) {
+  var row = sourceLength;
+  var column = matchEnd;
+  var tmpRow;
+  var tmpColumn;
+
+  while(row > 1) {
+   tmpRow = row;
+   tmpColumn = column;
+   row = distanceMatrix[tmpRow][tmpColumn].parentCell.row;
+   column = distanceMatrix[tmpRow][tmpColumn].parentCell.column;
+  }
+
+  return column-1;
+}
+
+function getMinCostSubstring(distanceMatrix, source, target) {
+  var sourceLength = source.length;
+  var targetLength = target.length;
+  var minDistance = sourceLength + targetLength;
+  var matchEnd = targetLength;
+
+  for (var column = 1; column <= targetLength; column++) {
+    if (minDistance > distanceMatrix[sourceLength][column].cost) {
+      minDistance = distanceMatrix[sourceLength][column].cost;
+      matchEnd = column;
+    }
+  }
+
+  matchStart = _getMatchStart(distanceMatrix, matchEnd, sourceLength);
+  return {substring: target.slice(matchStart, matchEnd), distance: minDistance};
+}
+
 function LevenshteinDistance (source, target, options) {
     options = options || {};
     if(isNaN(options.insertion_cost)) options.insertion_cost = 1;
     if(isNaN(options.deletion_cost)) options.deletion_cost = 1;
     if(isNaN(options.substitution_cost)) options.substitution_cost = 1;
+
+    if(typeof options.search !== 'boolean') options.search = false;
 
     var sourceLength = source.length;
     var targetLength = target.length;
@@ -77,7 +112,12 @@ function LevenshteinDistance (source, target, options) {
             distanceMatrix[row][column] = {cost: minCostParent.cost, parentCell: minCostParent.coordinates};
         }
     }
-    return distanceMatrix[sourceLength][targetLength].cost;
+
+    if (!options.search) {
+      return distanceMatrix[sourceLength][targetLength].cost;
+    }
+
+    return getMinCostSubstring(distanceMatrix, source, target);
 }
 
 module.exports = LevenshteinDistance;

--- a/spec/levenshtein_spec.js
+++ b/spec/levenshtein_spec.js
@@ -23,44 +23,75 @@ THE SOFTWARE.
 var levenshteinDistance = require('../lib/natural/distance/levenshtein_distance')
 
 describe('levenshtein_distance', function() {
-	it('should replace 2', function() {
-		expect(levenshteinDistance('doctor', 'doktor')).toBe(1);
-	});	
+  describe('options.search = true', function() {
+    it('should find 0 cost substring in target', function() {
+      expect(levenshteinDistance('doctor', 'the doctor is in', {search: true}))
+        .toEqual({substring: 'doctor', distance: 0});
+    });
 
-	it('should allow altering replacement value', function() {
-		expect(levenshteinDistance('doctor', 'doktor', {substitution_cost: 1})).toBe(1);
-	});	
+    it('should find 1 cost substring in target', function() {
+      expect(levenshteinDistance('doctor', 'the doktor is in', {search: true}))
+        .toEqual({substring: 'doktor', distance: 1});
+    });
 
-	it('should delete 1', function() {
-		expect(levenshteinDistance('doctor', 'docto')).toBe(1);
-	});
+    it('should return empty substring when that is cleapest match', function() {
+      expect(levenshteinDistance('doctor', '000000000000', {search: true}))
+        .toEqual({substring: '', distance: 6});
+    });
 
-	it('should insert 1', function() {
-		expect(levenshteinDistance('flat', 'flats')).toBe(1);
-	});
+    it('different insertion costs should work', function() {
+      // delete 10 0's at cost 1 and insert the letters for doctor at cost -1
+      expect(levenshteinDistance('0000000000', 'doctor', {search: true, insertion_cost: -1}))
+        .toEqual({substring: 'doctor', distance: 4});
+    });
 
-	it('should combine operations', function() {
-		expect(levenshteinDistance('flad', 'flaten')).toBe(3);
-		expect(levenshteinDistance('flaten', 'flad')).toBe(3);
-	});
+    it('different deletion costs should work', function() {
+      // delete 10 0's at cost -10
+      expect(levenshteinDistance('0000000000', 'doctor', {search: true, deletion_cost: -1}))
+        .toEqual({substring: '', distance: -10});
+    });
+  });
 
-	it('should consider perfect matches 0', function() {
-		expect(levenshteinDistance('one', 'one')).toBe(0);
-	});
+  describe('default / options.search = false', function() {
+    it('should replace 2', function() {
+      expect(levenshteinDistance('doctor', 'doktor')).toBe(1);
+    });
 
-    it('different deletion cost should work', function() {
-		expect(levenshteinDistance('ones', 'one', {deletion_cost: 3})).toBe(3);
-	});
+    it('should allow altering replacement value', function() {
+      expect(levenshteinDistance('doctor', 'doktor', {substitution_cost: 1})).toBe(1);
+    });
 
-    it('different insertion cost should work', function() {
-		expect(levenshteinDistance('one', 'ones', {deletion_cost: 3, insertion_cost: 5})).toBe(5);
-	});
+    it('should delete 1', function() {
+      expect(levenshteinDistance('doctor', 'docto')).toBe(1);
+    });
 
-    it('delete all characters with -ve cost', function() {
-		expect(levenshteinDistance('delete', '', {deletion_cost: -1})).toBe(-6);
-	});
+    it('should insert 1', function() {
+      expect(levenshteinDistance('flat', 'flats')).toBe(1);
+    });
 
-    it('insert all characters', function() {
-		expect(levenshteinDistance('', 'insert')).toBe(6);
-	});
+    it('should combine operations', function() {
+      expect(levenshteinDistance('flad', 'flaten')).toBe(3);
+      expect(levenshteinDistance('flaten', 'flad')).toBe(3);
+    });
+
+    it('should consider perfect matches 0', function() {
+      expect(levenshteinDistance('one', 'one')).toBe(0);
+    });
+
+      it('different deletion cost should work', function() {
+      expect(levenshteinDistance('ones', 'one', {deletion_cost: 3})).toBe(3);
+    });
+
+      it('different insertion cost should work', function() {
+      expect(levenshteinDistance('one', 'ones', {deletion_cost: 3, insertion_cost: 5})).toBe(5);
+    });
+
+      it('delete all characters with -ve cost', function() {
+      expect(levenshteinDistance('delete', '', {deletion_cost: -1})).toBe(-6);
+    });
+
+      it('insert all characters', function() {
+      expect(levenshteinDistance('', 'insert')).toBe(6);
+    });
+  })
 });

--- a/spec/levenshtein_spec.js
+++ b/spec/levenshtein_spec.js
@@ -24,6 +24,11 @@ var levenshteinDistance = require('../lib/natural/distance/levenshtein_distance'
 
 describe('levenshtein_distance', function() {
   describe('options.search = true', function() {
+    it('should find cheapest substring', function() {
+      expect(levenshteinDistance('kitten', 'sitting', {search: true}))
+        .toEqual({substring: 'sittin', distance: 2});
+    });
+
     it('should find 0 cost substring in target', function() {
       expect(levenshteinDistance('doctor', 'the doctor is in', {search: true}))
         .toEqual({substring: 'doctor', distance: 0});


### PR DESCRIPTION
## Summary
Be able to do approximate string searching in`O(n*m + n +m)`*:
```javascript
var s = 'The RainCoat BookStore';
var t = 'All the best books are here at the Rain Coats Book Store';
n.LevenshteinDistance(s, t)
 => { substring: 'the Rain Coats Book Store', distance: 4 }
```

## Details
This PR expands the existing Levenshtein Distance function to do approximate string searching as described in [this Wikipedia article](https://en.wikipedia.org/wiki/Approximate_string_matching#Problem_formulation_and_algorithms).

The main difference between using Levenshtein for distance calculation vs searching is (1) initializing the first row of the distance matrix with `0`s and (2) keeping track of the parent of each distance cell (i.e. is the current cell's cost a result of insertion/deletion/substitution). Then, do Levenshtein as usual.

With the distance matrix filled out, find the minimum value in the last row of the matrix. This will be the end of the closest substring match. Then walk back from this cell to the first row. The column position of the cell to which you've arrived in the first row is the start of the closest substring match.

## Why
This felt like an easy way to augment `natural`'s existing functionality to provide for pretty fast* approximate string searching.

 *`O(n*m + n + m)` where `n*m` is from the existing Levenshtein Search and the `n + m` part comes from traversing the distance matrix to build out the closest matching substring.