### PR TITLE
Allow setting of options to keep stops when using the stemmer

### DIFF
--- a/lib/natural/classifiers/classifier.js
+++ b/lib/natural/classifiers/classifier.js
@@ -58,7 +58,7 @@ function addDocument(text, classification) {
     }
 
     if(typeof text === 'string')
-	text = this.stemmer.tokenizeAndStem(text);
+	text = this.stemmer.tokenizeAndStem(text, this.keepStops);
 
     if(text.length === 0) {
         // ignore empty documents
@@ -82,7 +82,7 @@ function removeDocument(text, classification) {
     , pos;
 
   if (typeof text === 'string') {
-    text = this.stemmer.tokenizeAndStem(text);
+    text = this.stemmer.tokenizeAndStem(text, this.keepStops);
   }
 
   for (var i = 0, ii = docs.length; i < ii; i++) {
@@ -107,7 +107,7 @@ function textToFeatures(observation) {
     var features = [];
 
     if(typeof observation === 'string')
-	observation = this.stemmer.tokenizeAndStem(observation);
+	observation = this.stemmer.tokenizeAndStem(observation, this.keepStops);
 
     for(var feature in this.features) {
         if(observation.indexOf(feature) > -1)
@@ -180,7 +180,7 @@ function trainParallel(numThreads, callback) {
     for (var i = this.lastAdded; i < totalDocs; i++) {
         var observation = this.docs[i].text;
         if (typeof observation === 'string')
-            observation = this.stemmer.tokenizeAndStem(observation);
+            observation = this.stemmer.tokenizeAndStem(observation, this.keepStops);
         obsDocs.push({
             index: i,
             observation: observation
@@ -289,7 +289,7 @@ function trainParallelBatches(options) {
     for (var i = this.lastAdded; i < totalDocs; i++) {
         var observation = this.docs[i].text;
         if (typeof observation === 'string')
-            observation = this.stemmer.tokenizeAndStem(observation);
+            observation = this.stemmer.tokenizeAndStem(observation, this.keepStops);
         obsDocs.push({
             index: i,
             observation: observation
@@ -437,6 +437,10 @@ function load(filename, callback) {
     });
 }
 
+function setOptions(options){
+    this.keepStops = (options.keepStops) ? true : false;
+}
+
 Classifier.prototype.addDocument = addDocument;
 Classifier.prototype.removeDocument = removeDocument;
 Classifier.prototype.train = train;
@@ -448,6 +452,7 @@ Classifier.prototype.classify = classify;
 Classifier.prototype.textToFeatures = textToFeatures;
 Classifier.prototype.save = save;
 Classifier.prototype.getClassifications = getClassifications;
+Classifier.prototype.setOptions = setOptions;
 Classifier.restore = restore;
 Classifier.load = load;
 


### PR DESCRIPTION
Classifier is unable to match some exact inputs that it has been trained for. For example,
After a classifier has been trained with `classifier.addDocument('get', 'get');` and `classifier.addDocument('insert', 'insert');`, `classifier.classify('get');` returns insert instead of get.

This is because of the tokenizeAndStem function in the stemmer base not preserving stops, where some words are lost, which can be retained by giving the keepStops option.

This pull request brings this functionality to the classifier itself as an option.