### PR TITLE
Remove extra comma in levenstein distance.js

### DIFF
--- a/lib/natural/distance/levenshtein_distance.js
+++ b/lib/natural/distance/levenshtein_distance.js
@@ -92,7 +92,7 @@ function DamerauLevenshteinDistance(source, target, options) {
     var damLevOptions = _.assign(
         { transposition_cost: 1, restricted: false },
         options || {},
-        { damerau: true },
+        { damerau: true }
     );
     return levenshteinDistance(source, target, damLevOptions);
 }


### PR DESCRIPTION
Will return error: Unexpected token );