### PR TITLE
Fixed stemmer loading bug 

### DIFF
--- a/lib/natural/stemmers/indonesian/stemmer_id.js
+++ b/lib/natural/stemmers/indonesian/stemmer_id.js
@@ -131,11 +131,9 @@ function loadDictionary(){
     var fs = require('fs');
     var dirname = __dirname + "/../../../../data/kata-dasar.txt";
     var fin = fs.readFileSync(dirname).toString().split("\n");
-    for(var i in fin){
-        var word = fin[i];
-        word = word.trim();
-        dictionary.push(word);
-    }
+    fin.forEach(function (word) {
+        dictionary.push(word.trim());
+    });
 }
 
 // Stemming from step 2-5


### PR DESCRIPTION
In the code added a few months ago, it is iterating through every field in object fin instead of every item in array fin. This means at some point it was trying to call "trim" on Array.prototype.concat function incorrectly.