### PR TITLE
fix(wordnet): add callback to fs.close call

### DIFF
--- a/lib/natural/wordnet/wordnet_file.js
+++ b/lib/natural/wordnet/wordnet_file.js
@@ -53,7 +53,13 @@ function open(callback) {
         console.log('Unable to open %s', filePath);
         return;
     }
-    callback(err, fd, function() {fs.close(fd)});
+    callback(err, fd, function() {
+      fs.close(fd, function(error) {
+        if (error) {
+          throw error;
+        }
+      })
+    });
   });
 }
 


### PR DESCRIPTION
Calling an async function without callback is deprecated since node 7.

Related: https://github.com/NaturalNode/natural/issues/406