### PR TITLE
Fix [aeiou]y issue

### DIFF
--- a/lib/natural/inflectors/noun_inflector.js
+++ b/lib/natural/inflectors/noun_inflector.js
@@ -69,6 +69,7 @@ var NounInflector = function() {
     // see if it is possible to unify the creation of both the singular and
     // plural regexes or maybe even just have one list. with a complete list
     // of rules it may only be possible for some regular forms, but worth a shot
+    this.pluralForms.regularForms.push([/([aeiou]y)$/i, '$1s']);
     this.pluralForms.regularForms.push([/y$/i, 'ies']);
     this.pluralForms.regularForms.push([/ife$/i, 'ives']);
     this.pluralForms.regularForms.push([/(antenn|formul|nebul|vertebr|vit)a$/i, '$1ae']);

--- a/spec/noun_inflector_spec.js
+++ b/spec/noun_inflector_spec.js
@@ -227,6 +227,12 @@ describe('noun inflector', function() {
             expect(inflector.pluralize('monstrosity')).toBe('monstrosities');
         });
 
+        it('should handle [aeiou]Y cases', function() {
+          expect(inflector.pluralize('day')).toBe('days');
+          expect(inflector.pluralize('enjoy')).toBe('enjoys');
+          expect(inflector.pluralize('journey')).toBe('journeys');
+        });
+
         it('should handle SS cases', function() {
             expect(inflector.pluralize('dress')).toBe('dresses');
             expect(inflector.pluralize('dresses')).toBe('dresses');

--- a/spec/noun_inflector_spec.js
+++ b/spec/noun_inflector_spec.js
@@ -229,7 +229,7 @@ describe('noun inflector', function() {
 
         it('should handle [aeiou]Y cases', function() {
           expect(inflector.pluralize('day')).toBe('days');
-          expect(inflector.pluralize('enjoy')).toBe('enjoys');
+          expect(inflector.pluralize('toy')).toBe('toys');
           expect(inflector.pluralize('journey')).toBe('journeys');
         });
 


### PR DESCRIPTION
Nouns ending in a vowel plus 'y' should be pluralized by simply adding an 's'.

i.e.
days
toys
journeys