### PR TITLE
Fix sentiment

### DIFF
--- a/lib/natural/sentiment/SentimentAnalyzer.js
+++ b/lib/natural/sentiment/SentimentAnalyzer.js
@@ -42,28 +42,31 @@ const englishNegations = require("./English/negations_en.json").words;
 const spanishNegations = require("./Spanish/negations_es.json").words;
 const dutchNegations = require("./Dutch/negations_du.json").words;
 
+
 // Mapping from type of vocabulary to language to vocabulary
 var languageFiles = {
-  afinn: {
-    English: [englishAfinnVoca, englishNegations],
-    Spanish: [spanishAfinnVoca, spanishNegations]
+  "afinn" : {
+    "English": [englishAfinnVoca, englishNegations],
+    "Spanish": [spanishAfinnVoca, spanishNegations]
   },
-  senticon: {
-    Spanish: [spanishSenticonVoca, spanishNegations],
-    English: [englishSenticonVoca, englishNegations],
-    Galician: [galicianSenticonVoca, null],
-    Catalan: [catalanSenticonVoca, null],
-    Basque: [basqueSenticonVoca, null]
+  "senticon": {
+    "Spanish": [spanishSenticonVoca, spanishNegations],
+    "English": [englishSenticonVoca, englishNegations],
+    "Galician": [galicianSenticonVoca, null],
+    "Catalan": [catalanSenticonVoca, null],
+    "Basque": [basqueSenticonVoca, null]
   },
-  pattern: {
-    Dutch: [dutchPatternVoca, dutchNegations],
-    Italian: [italianPatternVoca, null],
-    English: [englishPatternVoca, englishNegations],
-    French: [frenchPatternVoca, null]
+  "pattern": {
+    "Dutch": [dutchPatternVoca, dutchNegations],
+    "Italian": [italianPatternVoca, null],
+    "English": [englishPatternVoca, englishNegations],
+    "French": [frenchPatternVoca, null]
   }
 };
 
+
 class SentimentAnalyzer {
+
   constructor(language, stemmer, type) {
     this.language = language;
     this.stemmer = stemmer;
@@ -71,16 +74,13 @@ class SentimentAnalyzer {
     // this.vocabulary must be a copy of the languageFiles object
     // or in subsequent execution the polarity will be undefined
     // shallow copy - requires ES6
-    this.vocabulary = Object.assign(
-      {},
-      require(languageFiles[type][language][0])
-    );
-
+    this.vocabulary = Object.assign({}, languageFiles[type][language][0]);
     if (type === "senticon") {
       Object.keys(this.vocabulary).forEach(word => {
         this.vocabulary[word] = this.vocabulary[word].pol;
       });
-    } else {
+    }
+    else {
       if (type == "pattern") {
         Object.keys(this.vocabulary).forEach(word => {
           this.vocabulary[word] = this.vocabulary[word].polarity;
@@ -96,8 +96,8 @@ class SentimentAnalyzer {
 
     if (stemmer) {
       var vocaStemmed = {};
-      for (var token in this.vocabulary) {
-        vocaStemmed[stemmer.stem(token)] = this.vocabulary[token];
+      for(var token in this.vocabulary) {
+            vocaStemmed[stemmer.stem(token)] = this.vocabulary[token];
       }
       this.vocabulary = vocaStemmed;
     }
@@ -109,20 +109,22 @@ class SentimentAnalyzer {
     var negator = 1;
     var nrHits = 0;
 
-    words.forEach(token => {
+    words.forEach((token) => {
       var lowerCased = token.toLowerCase();
       if (this.negations.indexOf(lowerCased) > -1) {
         negator = -1;
         nrHits++;
-      } else {
+      }
+      else {
         // First try without stemming
         if (this.vocabulary[lowerCased] != undefined) {
           score += negator * this.vocabulary[lowerCased];
           nrHits++;
-        } else {
+        }
+        else {
           if (this.stemmer) {
             var stemmedWord = this.stemmer.stem(lowerCased);
-            if (this.vocabulary[stemmedWord] != undefined) {
+            if(this.vocabulary[stemmedWord] != undefined) {
               score += negator * this.vocabulary[stemmedWord];
               nrHits++;
             }
@@ -136,6 +138,7 @@ class SentimentAnalyzer {
 
     return score;
   }
+
 }
 
 module.exports = SentimentAnalyzer;

--- a/lib/natural/sentiment/SentimentAnalyzer.js
+++ b/lib/natural/sentiment/SentimentAnalyzer.js
@@ -42,42 +42,44 @@ const englishNegations = require("./English/negations_en.json").words;
 const spanishNegations = require("./Spanish/negations_es.json").words;
 const dutchNegations = require("./Dutch/negations_du.json").words;
 
-
 // Mapping from type of vocabulary to language to vocabulary
 var languageFiles = {
-  "afinn" : {
-    "English": [englishAfinnVoca, englishNegations],
-    "Spanish": [spanishAfinnVoca, spanishNegations]
+  afinn: {
+    English: [englishAfinnVoca, englishNegations],
+    Spanish: [spanishAfinnVoca, spanishNegations]
   },
-  "senticon": {
-    "Spanish": [spanishSenticonVoca, spanishNegations],
-    "English": [englishSenticonVoca, englishNegations],
-    "Galician": [galicianSenticonVoca, null],
-    "Catalan": [catalanSenticonVoca, null],
-    "Basque": [basqueSenticonVoca, null]
+  senticon: {
+    Spanish: [spanishSenticonVoca, spanishNegations],
+    English: [englishSenticonVoca, englishNegations],
+    Galician: [galicianSenticonVoca, null],
+    Catalan: [catalanSenticonVoca, null],
+    Basque: [basqueSenticonVoca, null]
   },
-  "pattern": {
-    "Dutch": [dutchPatternVoca, dutchNegations],
-    "Italian": [italianPatternVoca, null],
-    "English": [englishPatternVoca, englishNegations],
-    "French": [frenchPatternVoca, null]
+  pattern: {
+    Dutch: [dutchPatternVoca, dutchNegations],
+    Italian: [italianPatternVoca, null],
+    English: [englishPatternVoca, englishNegations],
+    French: [frenchPatternVoca, null]
   }
 };
 
-
 class SentimentAnalyzer {
-
   constructor(language, stemmer, type) {
     this.language = language;
     this.stemmer = stemmer;
 
-    this.vocabulary = languageFiles[type][language][0];
+    // this.vocabulary must be a copy of the languageFiles object
+    // or in subsequent execution the polarity will be undefined
+    this.vocabulary = Object.assign(
+      {},
+      require(languageFiles[type][language][0])
+    );
+
     if (type === "senticon") {
       Object.keys(this.vocabulary).forEach(word => {
         this.vocabulary[word] = this.vocabulary[word].pol;
       });
-    }
-    else {
+    } else {
       if (type == "pattern") {
         Object.keys(this.vocabulary).forEach(word => {
           this.vocabulary[word] = this.vocabulary[word].polarity;
@@ -93,8 +95,8 @@ class SentimentAnalyzer {
 
     if (stemmer) {
       var vocaStemmed = {};
-      for(var token in this.vocabulary) {
-            vocaStemmed[stemmer.stem(token)] = this.vocabulary[token];
+      for (var token in this.vocabulary) {
+        vocaStemmed[stemmer.stem(token)] = this.vocabulary[token];
       }
       this.vocabulary = vocaStemmed;
     }
@@ -106,22 +108,20 @@ class SentimentAnalyzer {
     var negator = 1;
     var nrHits = 0;
 
-    words.forEach((token) => {
+    words.forEach(token => {
       var lowerCased = token.toLowerCase();
       if (this.negations.indexOf(lowerCased) > -1) {
         negator = -1;
         nrHits++;
-      }
-      else {
+      } else {
         // First try without stemming
         if (this.vocabulary[lowerCased] != undefined) {
           score += negator * this.vocabulary[lowerCased];
           nrHits++;
-        }
-        else {
+        } else {
           if (this.stemmer) {
             var stemmedWord = this.stemmer.stem(lowerCased);
-            if(this.vocabulary[stemmedWord] != undefined) {
+            if (this.vocabulary[stemmedWord] != undefined) {
               score += negator * this.vocabulary[stemmedWord];
               nrHits++;
             }
@@ -135,7 +135,6 @@ class SentimentAnalyzer {
 
     return score;
   }
-
 }
 
 module.exports = SentimentAnalyzer;


### PR DESCRIPTION
On line 74: `this.vocabulary = languageFiles[type][language][0];` assigns the vocabulary object to the object in the file, this means that both objects point to the same location.
Since later in the file we modify the `this.vocabulary` object structure: `this.vocabulary[word] = this.vocabulary[word].polarity;` the object imported with `require(languageFiles[type][language][0])`  will no longer have the polarity field from the original structure. 

After the second call to the SentimentAnalyzer object all the polarities will be undefined (this applies to "pattern" and "senticon"). Note that I created a shallow copy from the vocabulary object using the ES6 syntax from [here](https://stackoverflow.com/questions/728360/how-do-i-correctly-clone-a-javascript-object) :
`let clone = Object.assign({}, original);`

Line 74 is the only real change, the others are linted for readability, if not ok I can disable the linter.

Thanks for your amazing work!