### PR TITLE
Avoid throwing exception tokenizing one-sentence string

### DIFF
--- a/lib/natural/tokenizers/sentence_tokenizer.js
+++ b/lib/natural/tokenizers/sentence_tokenizer.js
@@ -36,6 +36,10 @@ SentenceTokenizer.prototype.tokenize = function(text) {
 
     DEBUG && console.log("SentenceTokenizer.tokenize: " + tokens);
 
+    if (!tokens) {
+        return [text];
+    }
+
     // remove unecessary white space
     tokens = tokens.map(Function.prototype.call, String.prototype.trim);
 


### PR DESCRIPTION
Sentence tokenizer now returns array of just the original string for one sentence strings