### PR TITLE
Minor indentation fix

### DIFF
--- a/lib/natural/wordnet/index_file.js
+++ b/lib/natural/wordnet/index_file.js
@@ -62,7 +62,7 @@ function findAt(fd, size, pos, lastPos, adjustment, searchKey, callback, lastKey
       var tokens = line.split(/\s+/);
       var key = tokens[0];
 
-    if(key == searchKey) {
+      if(key == searchKey) {
         callback({status: 'hit', key: key, 'line': line, tokens: tokens});
       } else if(adjustment == 1 || key == lastKey)  {
         miss(callback);


### PR DESCRIPTION
- Add a two space indentation to the `if(key == searchKey)` line