### PR TITLE
Fix "_ is not a function" error when webpacked

### DIFF
--- a/lib/natural/ngrams/ngrams.js
+++ b/lib/natural/ngrams/ngrams.js
@@ -74,7 +74,7 @@ var ngrams = function(sequence, n, startSymbol, endSymbol, stats) {
     frequencies = {};
     nrOfNgrams = 0;
     
-    if (!_(sequence).isArray()) {
+    if (!_.isArray(sequence)) {
         sequence = tokenizer.tokenize(sequence);
     }
 


### PR DESCRIPTION
In our application we use natural in lambda environment. To reduce size of bundle it is wrapped by webpack.
In such a case we are getting error `_ is not a function` on the line when all other dependencies work without issues. Not sure why is this happening but simple change to functional syntax that is being used across whole natural codebase fixes the issue.