### PR TITLE
Financial market news sentiment analysis support

### DIFF
--- a/lib/natural/sentiment/SentimentAnalyzer.js
+++ b/lib/natural/sentiment/SentimentAnalyzer.js
@@ -27,6 +27,9 @@ const englishAfinnVoca = require('afinn-165')
 const spanishAfinnVoca = require('./Spanish/afinnShortSortedSpanish.json')
 const portugueseAfinnVoca = require('./Portuguese/afinnShortSortedPortuguese.json')
 
+// Afinn Financial Market News
+const englishAfinnFinancialMarketNewsVoca = require('afinn-165-financialmarketnews')
+
 // Senticon
 const spanishSenticonVoca = require('./Spanish/senticon_es.json')
 const englishSenticonVoca = require('./English/senticon_en.json')
@@ -52,6 +55,9 @@ const languageFiles = {
     English: [englishAfinnVoca, englishNegations],
     Spanish: [spanishAfinnVoca, spanishNegations],
     Portuguese: [portugueseAfinnVoca, portugueseNegations]
+  },
+  afinnFinancialMarketNews: {
+    English: [englishAfinnFinancialMarketNewsVoca, englishNegations],
   },
   senticon: {
     Spanish: [spanishSenticonVoca, spanishNegations],

--- a/lib/natural/sentiment/SentimentAnalyzer.js
+++ b/lib/natural/sentiment/SentimentAnalyzer.js
@@ -28,7 +28,9 @@ const spanishAfinnVoca = require('./Spanish/afinnShortSortedSpanish.json')
 const portugueseAfinnVoca = require('./Portuguese/afinnShortSortedPortuguese.json')
 
 // Afinn Financial Market News
-const englishAfinnFinancialMarketNewsVoca = require('afinn-165-financialmarketnews')
+// const englishAfinnFinancialMarketNewsVoca = require('afinn-165-financialmarketnews')
+// Use ESM syntax
+import englishAfinnFinancialMarketNewsVoca from 'afinn-165-financialmarketnews'
 
 // Senticon
 const spanishSenticonVoca = require('./Spanish/senticon_es.json')

--- a/lib/natural/sentiment/SentimentAnalyzer.js
+++ b/lib/natural/sentiment/SentimentAnalyzer.js
@@ -57,7 +57,7 @@ const languageFiles = {
     Portuguese: [portugueseAfinnVoca, portugueseNegations]
   },
   afinnFinancialMarketNews: {
-    English: [englishAfinnFinancialMarketNewsVoca, englishNegations],
+    English: [englishAfinnFinancialMarketNewsVoca, englishNegations]
   },
   senticon: {
     Spanish: [spanishSenticonVoca, spanishNegations],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "afinn-165": "^1.0.2",
+        "afinn-165-financialmarketnews": "^2.0.2",
         "apparatus": "^0.0.10",
         "safe-stable-stringify": "^2.2.0",
         "stopwords-iso": "^1.1.0",
@@ -875,6 +876,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
       "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/afinn-165-financialmarketnews": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-2.0.2.tgz",
+      "integrity": "sha512-IyDXzPZ73kmfQua+rqTkkpMbnFI0QAAgkVxyB8Hz8gqdfkMfNVKfuY7BCLfbnDZGCgLmYylbjngPUSJWvsYyvQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12280,6 +12290,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
       "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA=="
+    },
+    "afinn-165-financialmarketnews": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-2.0.2.tgz",
+      "integrity": "sha512-IyDXzPZ73kmfQua+rqTkkpMbnFI0QAAgkVxyB8Hz8gqdfkMfNVKfuY7BCLfbnDZGCgLmYylbjngPUSJWvsYyvQ=="
     },
     "aggregate-error": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "afinn-165": "^1.0.2",
+    "afinn-165-financialmarketnews": "^2.0.2",
     "apparatus": "^0.0.10",
     "safe-stable-stringify": "^2.2.0",
     "stopwords-iso": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git://github.com/NaturalNode/natural.git"
   },
+  "type": "module",
   "engines": {
     "node": ">=0.4.10"
   },


### PR DESCRIPTION
This PR adds an additional AFINN-165 word list to the sentiment analyzer that is geared towards parsing financial market news (e.g. news about a stock/equity).

The `type` that is passed is 'afinnFinancialMarketNews' with the current language that is supported being 'English'.

