### PR TITLE
Update TS declarations

### DIFF
--- a/lib/natural/analyzers/index.d.ts
+++ b/lib/natural/analyzers/index.d.ts
@@ -21,33 +21,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare type TaggedWord = {
+export declare interface TaggedWord {
   token: string
   pos: string
+  pp?: boolean
   spos?: string
   added?: boolean
-} | { [key: string]: string | undefined }
+}
 
 export declare type PunctuationFunction = () => string[] | ''
 
 export declare interface TaggedSentence {
   tags: TaggedWord[]
-  punct?: PunctuationFunction
+  punct: PunctuationFunction
 }
 
 export declare type CallbackFunction = (obj: SentenceAnalyzer) => void
 
-export declare type SenType = string
+export declare enum SenType {
+  Unknown = 'UNKNOWN',
+  Command = 'COMMAND',
+  Interrogative = 'INTERROGATIVE',
+  Exclamatory = 'EXCLAMATORY',
+  Declarative = 'DECLARATIVE',
+}
 
 export declare class SentenceAnalyzer {
   posObj: TaggedSentence
-  senType: string | null
+  senType: SenType | null
 
   constructor (pos: TaggedSentence, cbf: CallbackFunction)
   part (cbf: CallbackFunction): void
   prepositionPhrases (): void
-  subjectToString (): string | null
-  predicateToString (): string | null
+  subjectToString (): string
+  predicateToString (): string
   implicitYou (): boolean
   toString (): string
   type (cbf: CallbackFunction): SenType

--- a/lib/natural/analyzers/index.d.ts
+++ b/lib/natural/analyzers/index.d.ts
@@ -21,13 +21,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare interface TaggedWord {
-  [key: string]: string
+export declare type TaggedWord = {
   token: string
   pos: string
   spos?: string
   added?: boolean
-}
+} | { [key: string]: string | undefined }
 
 export declare type PunctuationFunction = () => string[] | ''
 

--- a/lib/natural/analyzers/index.d.ts
+++ b/lib/natural/analyzers/index.d.ts
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare interface TaggedWord {
+declare interface TaggedWord {
   token: string
   pos: string
   pp?: boolean
@@ -29,16 +29,16 @@ export declare interface TaggedWord {
   added?: boolean
 }
 
-export declare type PunctuationFunction = () => string[] | ''
+declare type PunctuationFunction = () => string[] | ''
 
-export declare interface TaggedSentence {
+declare interface TaggedSentence {
   tags: TaggedWord[]
   punct: PunctuationFunction
 }
 
-export declare type CallbackFunction = (obj: SentenceAnalyzer) => void
+declare type CallbackFunction = (obj: SentenceAnalyzer) => void
 
-export declare enum SenType {
+declare enum SenType {
   Unknown = 'UNKNOWN',
   Command = 'COMMAND',
   Interrogative = 'INTERROGATIVE',
@@ -46,7 +46,7 @@ export declare enum SenType {
   Declarative = 'DECLARATIVE',
 }
 
-export declare class SentenceAnalyzer {
+export class SentenceAnalyzer {
   posObj: TaggedSentence
   senType: SenType | null
 

--- a/lib/natural/brill_pos_tagger/index.d.ts
+++ b/lib/natural/brill_pos_tagger/index.d.ts
@@ -23,13 +23,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+export interface RuleTemplate {
+  function: (sentence: Sentence, i: number, parameter1?: string, parameter2?: string) => boolean
+  window: number[]
+  nrParameters: number
+  parameter1Values?: (sentence: Sentence, i: number) => string[]
+  parameter2Values?: (sentence: Sentence, i: number) => string[]
+}
+
+export interface RuleTemplates {
+  [key: string]: RuleTemplate | undefined
+}
+
 export declare class Predicate {
   constructor (name: string, parameter1: string, parameter2?: string)
   name: string
   parameter1: string
-  parameter2?: string | undefined
-  function?: ((tagged_sentence: string[][], i: number, parameter: string) => boolean) | undefined
-  evaluate (taggedSentence: string[][], position: number): boolean
+  parameter2: string | undefined
+  meta: RuleTemplate
+  evaluate (sentence: Sentence, position: number): boolean
 }
 
 export declare class TransformationRule {
@@ -38,19 +50,57 @@ export declare class TransformationRule {
   predicate: Predicate
   old_category: string
   new_category: string
-  apply (taggedSentence: string[][], position: number): void
+  neutral: number
+  positive: number
+  negative: number
+  hasBeenSelectedAsHighRuleBefore: boolean
+  key (): string
+  apply (sentence: Sentence, position: number): void
+  isApplicableAt (sentence: Sentence, taggedSentence: Sentence, i: number): boolean
+  prettyPrint (): string
+  applyAt (sentence: Sentence, position: number): void
+  score (): number
 }
 
 export declare class RuleSet {
-  constructor (filename: string)
+  constructor (language: string)
   rules: TransformationRule[]
+  addRule (rule: TransformationRule): boolean
+  removeRule (rule: TransformationRule): void
+  getRules (): TransformationRule[]
+  nrRules (): number
+  hasRule (rule: TransformationRule): boolean
+  prettyPrint (): string
 }
 
 export declare class Lexicon {
-  constructor (filename: string, defaultCategory: string)
+  constructor (language: string, defaultCategory: string, defaultCategoryCapitalised?: string)
+  lexicon: { [key: string]: string[] | undefined }
   defaultCategory: string
+  defaultCategoryCapitalised: string | undefined
   parseLexicon (data: string): void
+  tagWordWithDefaults (word: string): string
   tagWord (word: string): string[]
+  addWord (word: string, categories: string[]): void
+  prettyPrint (): string
+  nrEntries (): number
+  size (): number
+  setDefaultCategories (category: string, categoryCapitalised: string): void
+}
+
+export declare class Corpus {
+  constructor (data: string | Corpus, typeOfCorpus: number, SentenceClass: typeof Sentence)
+  parseBrownCorpus (data: string, SentenceClass: typeof Sentence): void
+  getTags (): string[]
+  splitInTrainAndTest (percentageTrain: number): [Corpus, Corpus]
+  analyse (): void
+  buildLexicon (): Lexicon
+  tag (lexicon: Lexicon): void
+  nrSentences (): number
+  nrWords (): number
+  // Incomplete methods
+  // generateFeatures
+  // prettyPrint
 }
 
 export interface BrillPOSTaggedWord {

--- a/lib/natural/brill_pos_tagger/index.d.ts
+++ b/lib/natural/brill_pos_tagger/index.d.ts
@@ -53,14 +53,14 @@ export declare class Lexicon {
   tagWord (word: string): string[]
 }
 
-export interface TaggedWord {
+export interface BrillPOSTaggedWord {
   token: string
   tag: string
 }
 
 export declare class Sentence {
   constructor (data?: string[])
-  taggedWords: TaggedWord[]
+  taggedWords: BrillPOSTaggedWord[]
   addTaggedWord (token: string, tag: string): void
   clone (): Sentence
 }

--- a/lib/natural/brill_pos_tagger/index.d.ts
+++ b/lib/natural/brill_pos_tagger/index.d.ts
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-interface RuleTemplatesItem {
+declare interface RuleTemplatesItem {
   function: (sentence: Sentence, i: number, parameter1?: string, parameter2?: string) => boolean
   window: number[]
   nrParameters: number
@@ -35,12 +35,12 @@ export interface RuleTemplates {
   [key: string]: RuleTemplatesItem | undefined
 }
 
-export declare class RuleTemplate {
+export class RuleTemplate {
   constructor (templateName: string, metadata: RuleTemplatesItem)
   windowFitsSite (sentence: Sentence, i: number): void
 }
 
-export declare class Predicate {
+declare class Predicate {
   constructor (name: string, parameter1: string, parameter2?: string)
   name: string
   parameter1: string
@@ -49,7 +49,7 @@ export declare class Predicate {
   evaluate (sentence: Sentence, position: number): boolean
 }
 
-export declare class TransformationRule {
+declare class TransformationRule {
   constructor (c1: string, c2: string, predicate: string, parameter1: string, parameter2?: string)
   literal: string[]
   predicate: Predicate
@@ -67,7 +67,7 @@ export declare class TransformationRule {
   score (): number
 }
 
-export declare class RuleSet {
+export class RuleSet {
   constructor (language: string)
   rules: TransformationRule[]
   addRule (rule: TransformationRule): boolean
@@ -78,7 +78,7 @@ export declare class RuleSet {
   prettyPrint (): string
 }
 
-export declare class Lexicon {
+export class Lexicon {
   constructor (language: string, defaultCategory: string, defaultCategoryCapitalised?: string)
   lexicon: { [key: string]: string[] | undefined }
   defaultCategory: string
@@ -93,7 +93,7 @@ export declare class Lexicon {
   setDefaultCategories (category: string, categoryCapitalised: string): void
 }
 
-export declare class Corpus {
+export class Corpus {
   constructor (data: string | Corpus, typeOfCorpus: number, SentenceClass: typeof Sentence)
   parseBrownCorpus (data: string, SentenceClass: typeof Sentence): void
   getTags (): string[]
@@ -108,19 +108,19 @@ export declare class Corpus {
   // prettyPrint
 }
 
-export interface BrillPOSTaggedWord {
+declare interface BrillPOSTaggedWord {
   token: string
   tag: string
 }
 
-export declare class Sentence {
+export class Sentence {
   constructor (data?: string[])
   taggedWords: BrillPOSTaggedWord[]
   addTaggedWord (token: string, tag: string): void
   clone (): Sentence
 }
 
-export declare class BrillPOSTagger {
+export class BrillPOSTagger {
   constructor (lexicon: Lexicon, ruleSet: RuleSet)
   lexicon: Lexicon
   ruleSet: RuleSet
@@ -129,14 +129,14 @@ export declare class BrillPOSTagger {
   applyRules (sentence: Sentence): Sentence
 }
 
-export declare class BrillPOSTester {
+export class BrillPOSTester {
   constructor (lexicon: Lexicon, ruleSet: RuleSet)
   lexicon: Lexicon
   ruleSet: RuleSet
   test (corpus: Corpus, tagger: BrillPOSTagger): [number, number]
 }
 
-export declare class BrillPOSTrainer {
+export class BrillPOSTrainer {
   constructor (ruleScoreThreshold: number)
   ruleScoreThreshold: number
   corpus: Corpus

--- a/lib/natural/brill_pos_tagger/index.d.ts
+++ b/lib/natural/brill_pos_tagger/index.d.ts
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export interface RuleTemplate {
+interface RuleTemplatesItem {
   function: (sentence: Sentence, i: number, parameter1?: string, parameter2?: string) => boolean
   window: number[]
   nrParameters: number
@@ -32,7 +32,12 @@ export interface RuleTemplate {
 }
 
 export interface RuleTemplates {
-  [key: string]: RuleTemplate | undefined
+  [key: string]: RuleTemplatesItem | undefined
+}
+
+export declare class RuleTemplate {
+  constructor (templateName: string, metadata: RuleTemplatesItem)
+  windowFitsSite (sentence: Sentence, i: number): void
 }
 
 export declare class Predicate {
@@ -40,7 +45,7 @@ export declare class Predicate {
   name: string
   parameter1: string
   parameter2: string | undefined
-  meta: RuleTemplate
+  meta: RuleTemplatesItem
   evaluate (sentence: Sentence, position: number): boolean
 }
 
@@ -120,4 +125,38 @@ export declare class BrillPOSTagger {
   lexicon: Lexicon
   ruleSet: RuleSet
   tag (sentence: string[]): Sentence
+  tagWithLexicon (sentence: string[]): Sentence
+  applyRules (sentence: Sentence): Sentence
+}
+
+export declare class BrillPOSTester {
+  constructor (lexicon: Lexicon, ruleSet: RuleSet)
+  lexicon: Lexicon
+  ruleSet: RuleSet
+  test (corpus: Corpus, tagger: BrillPOSTagger): [number, number]
+}
+
+export declare class BrillPOSTrainer {
+  constructor (ruleScoreThreshold: number)
+  ruleScoreThreshold: number
+  corpus: Corpus
+  templates: RuleTemplates
+  positiveRules: RuleSet
+  mapRuleToSites: { [key: string]: { [key: number ]: { [key: number ]: boolean | undefined } | undefined } | undefined }
+  mapSiteToRules: { [key: number]: { [key: number ]: { [key: string ]: TransformationRule | undefined } | undefined } | undefined }
+  selectHighRule (): TransformationRule
+  mapRuleToSite (rule: TransformationRule, i: number, j: number): void
+  mapSiteToRule (i: number, j: number, rule: TransformationRule): void
+  associateSiteWithRule (i: number, j: number, rule: TransformationRule): void
+  siteIsAssociatedWithRule (i: number, j: number, rule: TransformationRule): boolean
+  getSites (rule: TransformationRule): [number, number][]
+  getRules (i: number, j: number): TransformationRule[]
+  disconnectSiteFromRule (i: number, j: number, rule: TransformationRule): void
+  scoreRule (rule: TransformationRule, i: number, j: number): void
+  generatePositiveRules (i: number, j: number): RuleSet
+  scanForPositiveRules (): void
+  scanForSites (): void
+  neighbourhood (i: number, j: number): [number, number][]
+  train (corpus: Corpus, templates: RuleTemplates, lexicon: Lexicon): RuleSet
+  printRulesWithScores (): string
 }

--- a/lib/natural/brill_pos_tagger/index.d.ts
+++ b/lib/natural/brill_pos_tagger/index.d.ts
@@ -149,14 +149,14 @@ export declare class BrillPOSTrainer {
   mapSiteToRule (i: number, j: number, rule: TransformationRule): void
   associateSiteWithRule (i: number, j: number, rule: TransformationRule): void
   siteIsAssociatedWithRule (i: number, j: number, rule: TransformationRule): boolean
-  getSites (rule: TransformationRule): [number, number][]
+  getSites (rule: TransformationRule): Array<[number, number]>
   getRules (i: number, j: number): TransformationRule[]
   disconnectSiteFromRule (i: number, j: number, rule: TransformationRule): void
   scoreRule (rule: TransformationRule, i: number, j: number): void
   generatePositiveRules (i: number, j: number): RuleSet
   scanForPositiveRules (): void
   scanForSites (): void
-  neighbourhood (i: number, j: number): [number, number][]
+  neighbourhood (i: number, j: number): Array<[number, number]>
   train (corpus: Corpus, templates: RuleTemplates, lexicon: Lexicon): RuleSet
   printRulesWithScores (): string
 }

--- a/lib/natural/classifiers/index.d.ts
+++ b/lib/natural/classifiers/index.d.ts
@@ -190,7 +190,7 @@ declare class Sample {
 }
 
 declare class Context {
-  key: string | undefined;
+  key: string | undefined
 
   constructor (data: any)
   toString (): string

--- a/lib/natural/classifiers/index.d.ts
+++ b/lib/natural/classifiers/index.d.ts
@@ -63,7 +63,7 @@ export interface ClassifierOptions {
   keepStops?: boolean
 }
 
-export type ClassifierCallback = (err: NodeJS.ErrnoException, classifier?: ClassifierBase) => void
+export type ClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: ClassifierBase) => void
 
 declare class ClassifierBase {
   classifier: ApparatusClassifier
@@ -85,7 +85,7 @@ declare class ClassifierBase {
   save (filename: string, callback: ClassifierCallback): void
 }
 
-export type BayesClassifierCallback = (err: NodeJS.ErrnoException, classifier?: BayesClassifier) => void
+export type BayesClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: BayesClassifier) => void
 
 export declare class BayesClassifier extends ClassifierBase {
   constructor (stemmer?: Stemmer, smoothing?: number)
@@ -93,7 +93,7 @@ export declare class BayesClassifier extends ClassifierBase {
   static restore (classifier: BayesClassifier, stemmer?: Stemmer): BayesClassifier
 }
 
-export type LogisticRegressionClassifierCallback = (err: NodeJS.ErrnoException, classifier?: LogisticRegressionClassifier) => void
+export type LogisticRegressionClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: LogisticRegressionClassifier) => void
 
 export declare class LogisticRegressionClassifier extends ClassifierBase {
   constructor (stemmer?: Stemmer)
@@ -101,7 +101,7 @@ export declare class LogisticRegressionClassifier extends ClassifierBase {
   static restore (classifier: LogisticRegressionClassifier, stemmer?: Stemmer): LogisticRegressionClassifier
 }
 
-export type MaxEntClassifierCallback = (err: NodeJS.ErrnoException, classifier?: MaxEntClassifier | null) => void
+export type MaxEntClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: MaxEntClassifier | null) => void
 
 declare class MaxEntClassifier {
   sample: Sample

--- a/lib/natural/classifiers/index.d.ts
+++ b/lib/natural/classifiers/index.d.ts
@@ -70,17 +70,17 @@ declare class Distribution {
 
   constructor (alpha: number[], features: FeatureSet, sample: Sample)
   toString (): string
-  weight(x: Element): number
-  calculateAPriori(x: Element): number
-  prepareWeights(): void
-  calculateAPosteriori(x: Element): number
-  aPosterioriNormalisation(b: Context): number
-  prepareAPosterioris(): void
-  prepare(): void
-  KullbackLieblerDistance(): number
-  logLikelihood(): number
-  entropy(): number
-  checkSum(): number
+  weight (x: Element): number
+  calculateAPriori (x: Element): number
+  prepareWeights (): void
+  calculateAPosteriori (x: Element): number
+  aPosterioriNormalisation (b: Context): number
+  prepareAPosterioris (): void
+  prepare (): void
+  KullbackLieblerDistance (): number
+  logLikelihood (): number
+  entropy (): number
+  checkSum (): number
 }
 
 export type FeatureFunction = (x: Element) => number

--- a/lib/natural/classifiers/index.d.ts
+++ b/lib/natural/classifiers/index.d.ts
@@ -14,12 +14,12 @@ import { Stemmer } from '../stemmers'
 //   Observation as ApparatusObservation,
 // } from 'apparatus'
 
-export interface ApparatusClassification {
+declare interface ApparatusClassification {
   label: string
   value: number
 }
 
-export type ApparatusObservation = number[] | { [key: string]: number | string | boolean | undefined }
+declare type ApparatusObservation = number[] | { [key: string]: number | string | boolean | undefined }
 
 declare class ApparatusClassifier {
   addExample (observation: ApparatusObservation, label: string): void
@@ -61,16 +61,16 @@ declare class ApparatusLogisticRegressionClassifier extends ApparatusClassifier 
 
 // End apparatus declarations
 
-export interface ClassifierDoc {
+declare interface ClassifierDoc {
   label: string
   text: string
 }
 
-export interface ClassifierOptions {
+declare interface ClassifierOptions {
   keepStops?: boolean
 }
 
-export type ClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: ClassifierBase) => void
+declare type ClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: ClassifierBase) => void
 
 declare class ClassifierBase {
   classifier: ApparatusClassifier
@@ -92,25 +92,25 @@ declare class ClassifierBase {
   save (filename: string, callback: ClassifierCallback): void
 }
 
-export type BayesClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: BayesClassifier) => void
+declare type BayesClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: BayesClassifier) => void
 
-declare class BayesClassifier extends ClassifierBase {
+export class BayesClassifier extends ClassifierBase {
   constructor (stemmer?: Stemmer, smoothing?: number)
   static load (filename: string, stemmer: Stemmer | null | undefined, callback: BayesClassifierCallback): void
   static restore (classifier: BayesClassifier, stemmer?: Stemmer): BayesClassifier
 }
 
-export type LogisticRegressionClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: LogisticRegressionClassifier) => void
+declare type LogisticRegressionClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: LogisticRegressionClassifier) => void
 
-declare class LogisticRegressionClassifier extends ClassifierBase {
+export class LogisticRegressionClassifier extends ClassifierBase {
   constructor (stemmer?: Stemmer)
   static load (filename: string, stemmer: Stemmer | null | undefined, callback: LogisticRegressionClassifierCallback): void
   static restore (classifier: LogisticRegressionClassifier, stemmer?: Stemmer): LogisticRegressionClassifier
 }
 
-export type MaxEntClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: MaxEntClassifier | null) => void
+declare type MaxEntClassifierCallback = (err: NodeJS.ErrnoException | null, classifier?: MaxEntClassifier | null) => void
 
-declare class MaxEntClassifier {
+export class MaxEntClassifier {
   sample: Sample
   features: FeatureSet
 
@@ -145,9 +145,9 @@ declare class Distribution {
   checkSum (): number
 }
 
-export type FeatureFunction = (x: Element) => number
+declare type FeatureFunction = (x: Element) => number
 
-declare class Feature {
+export class Feature {
   evaluate: FeatureFunction
   name: string
   parameters: string[]
@@ -159,7 +159,7 @@ declare class Feature {
   observedExpectation (sample: Sample): number
 }
 
-declare class FeatureSet {
+export class FeatureSet {
   features: Feature[]
   map: { [key: string]: boolean | undefined }
 
@@ -170,9 +170,9 @@ declare class FeatureSet {
   prettyPrint (): string
 }
 
-export type SampleCallback = (err: NodeJS.ErrnoException | null, sample?: Sample | null) => void
+declare type SampleCallback = (err: NodeJS.ErrnoException | null, sample?: Sample | null) => void
 
-declare class Sample {
+export class Sample {
   frequencyOfContext: { [key: string]: number | undefined }
   frequency: { [key: string]: number | undefined }
   classes: string[]
@@ -189,14 +189,14 @@ declare class Sample {
   load (filename: string, elementClass: typeof Element, callback: SampleCallback): void
 }
 
-declare class Context {
+export class Context {
   key: string | undefined
 
   constructor (data: any)
   toString (): string
 }
 
-declare class Element {
+export class Element {
   a: string
   b: Context
   key: string | undefined
@@ -205,29 +205,29 @@ declare class Element {
   toString (): string
 }
 
-declare class SEElement extends Element {
+export class SEElement extends Element {
   constructor (a: string, b: Context)
   generateFeatures (featureSet: FeatureSet): void
 }
 
-declare class POSElement extends Element {
+export class POSElement extends Element {
   constructor (a: string, b: Context)
   generateFeatures (featureSet: FeatureSet): void
 }
 
-declare class GISScaler {
+export class GISScaler {
   constructor (featureSet: FeatureSet, sample: Sample)
   calculateMaxSumOfFeatures (): boolean
   addCorrectionFeature (): void
   run (maxIterations: number, minImprovement: number): Distribution
 }
 
-declare class MESentence {
+export class MESentence {
   constructor (data?: string[])
   generateSampleElements (sample: Sample): void
 }
 
-declare class MECorpus {
+export class MECorpus {
   constructor (data: string | Corpus, BROWN: number, SentenceClass: typeof Sentence)
   generateSample (): Sample
   splitInTrainAndTest (percentageTrain: number): [MECorpus, MECorpus]

--- a/lib/natural/distance/index.d.ts
+++ b/lib/natural/distance/index.d.ts
@@ -24,32 +24,37 @@ THE SOFTWARE.
 // Based on type definitions on Definitely Typed
 
 export interface JaroWinklerOptions {
-  dj?: number | undefined
-  // default: false
-  ignoreCase?: boolean | undefined
+  dj?: number
+  /** @default false */
+  ignoreCase?: boolean
 }
+
 export declare function JaroWinklerDistance (s1: string, s2: string, options: JaroWinklerOptions): number
 
 export interface DamerauLevenshteinDistanceOptions {
   /** @default 1 */
-  insertion_cost?: number | undefined
+  insertion_cost?: number
   /** @default 1 */
-  deletion_cost?: number | undefined
+  deletion_cost?: number
   /** @default 1 */
-  substitution_cost?: number | undefined
+  substitution_cost?: number
   /** @default 1 */
-  transposition_cost?: number | undefined
+  transposition_cost?: number
   /** @default false */
-  search?: boolean | undefined
+  search?: boolean
   /** @default false */
-  restricted?: boolean | undefined
-  damerau?: boolean | undefined
+  restricted?: boolean
+  damerau?: boolean
 }
-interface SubstringDistanceResult {
+
+export interface SubstringDistanceResult {
   substring: string
   distance: number
+  offset: number
 }
+
 export declare function LevenshteinDistance (source: string, target: string, options?: DamerauLevenshteinDistanceOptions): number
+
 /**
  * Returns the Damerau-Levenshtein distance between strings. Counts the distance
  * between two strings by returning the number of edit operations required to
@@ -63,14 +68,19 @@ export function DamerauLevenshteinDistance (
   target: string,
   options: DamerauLevenshteinDistanceOptions & { search: true }
 ): SubstringDistanceResult
+
 export function DamerauLevenshteinDistance (
   source: string,
   target: string,
-  options?: DamerauLevenshteinDistanceOptions & { search?: false | undefined }
+  options?: DamerauLevenshteinDistanceOptions & { search?: false }
 ): number
+
 export function DamerauLevenshteinDistance (
   source: string,
   target: string,
   options: DamerauLevenshteinDistanceOptions & { search: boolean }
 ): number | SubstringDistanceResult
+
 export declare function DiceCoefficient (str1: string, str2: string): number
+
+export declare function HammingDistance (str1: string, str2: string, ignoreCase: boolean): number

--- a/lib/natural/distance/index.d.ts
+++ b/lib/natural/distance/index.d.ts
@@ -23,15 +23,15 @@ THE SOFTWARE.
 
 // Based on type definitions on Definitely Typed
 
-export interface JaroWinklerOptions {
+declare interface JaroWinklerOptions {
   dj?: number
   /** @default false */
   ignoreCase?: boolean
 }
 
-export declare function JaroWinklerDistance (s1: string, s2: string, options: JaroWinklerOptions): number
+export function JaroWinklerDistance (s1: string, s2: string, options: JaroWinklerOptions): number
 
-export interface DamerauLevenshteinDistanceOptions {
+declare interface DamerauLevenshteinDistanceOptions {
   /** @default 1 */
   insertion_cost?: number
   /** @default 1 */
@@ -47,13 +47,17 @@ export interface DamerauLevenshteinDistanceOptions {
   damerau?: boolean
 }
 
-export interface SubstringDistanceResult {
+declare interface SubstringDistanceResult {
   substring: string
   distance: number
   offset: number
 }
 
-export declare function LevenshteinDistance (source: string, target: string, options?: DamerauLevenshteinDistanceOptions): number
+export function LevenshteinDistance (
+  source: string,
+  target: string,
+  options?: DamerauLevenshteinDistanceOptions
+): number
 
 /**
  * Returns the Damerau-Levenshtein distance between strings. Counts the distance
@@ -81,6 +85,6 @@ export function DamerauLevenshteinDistance (
   options: DamerauLevenshteinDistanceOptions & { search: boolean }
 ): number | SubstringDistanceResult
 
-export declare function DiceCoefficient (str1: string, str2: string): number
+export function DiceCoefficient (str1: string, str2: string): number
 
-export declare function HammingDistance (str1: string, str2: string, ignoreCase: boolean): number
+export function HammingDistance (str1: string, str2: string, ignoreCase: boolean): number

--- a/lib/natural/inflectors/index.d.ts
+++ b/lib/natural/inflectors/index.d.ts
@@ -25,8 +25,8 @@ export declare class NounInflector {
   singularize (token: string): string
 }
 
-export declare let CountInflector: {
-  nth: (i: number) => string
+export declare class CountInflector {
+  static nth (i: number): string
 }
 
 export declare class PresentVerbInflector {

--- a/lib/natural/inflectors/index.d.ts
+++ b/lib/natural/inflectors/index.d.ts
@@ -26,7 +26,7 @@ declare class NounInflector {
 }
 
 declare interface CountInflector {
-  nth (i: number): string
+  nth: (i: number) => string
 }
 
 declare class PresentVerbInflector {

--- a/lib/natural/inflectors/index.d.ts
+++ b/lib/natural/inflectors/index.d.ts
@@ -20,16 +20,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare class NounInflector {
+declare class NounInflector {
   pluralize (token: string): string
   singularize (token: string): string
 }
 
-export declare class CountInflector {
-  static nth (i: number): string
+declare interface CountInflector {
+  nth (i: number): string
 }
 
-export declare class PresentVerbInflector {
+declare class PresentVerbInflector {
   pluralize (token: string): string
   singularize (token: string): string
 }

--- a/lib/natural/inflectors/index.d.ts
+++ b/lib/natural/inflectors/index.d.ts
@@ -20,16 +20,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-declare class NounInflector {
+export class NounInflector {
   pluralize (token: string): string
   singularize (token: string): string
 }
 
-declare interface CountInflector {
+export let CountInflector: {
   nth: (i: number) => string
 }
 
-declare class PresentVerbInflector {
+export class PresentVerbInflector {
   pluralize (token: string): string
   singularize (token: string): string
 }

--- a/lib/natural/inflectors/index.d.ts
+++ b/lib/natural/inflectors/index.d.ts
@@ -25,6 +25,9 @@ export class NounInflector {
   singularize (token: string): string
 }
 
+export class NounInflectorFr extends NounInflector {}
+export class NounInflectorJa extends NounInflector {}
+
 export let CountInflector: {
   nth: (i: number) => string
 }

--- a/lib/natural/ngrams/index.d.ts
+++ b/lib/natural/ngrams/index.d.ts
@@ -32,6 +32,9 @@ declare interface NGramsStats {
 }
 
 declare interface NGramsFunctions {
+  // To support function overloads where the return type can differ depending on a parameter
+  // value, method signatures are necessary. Key collisions occur with property signatures.
+  /* eslint-disable @typescript-eslint/method-signature-style */
   setTokenizer (t: Tokenizer): void
   ngrams (sequence: string | string[], n: number, startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
   ngrams (sequence: string | string[], n: number, startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
@@ -41,6 +44,7 @@ declare interface NGramsFunctions {
   trigrams (sequence: string | string[], startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
   multrigrams (sequence: string | string[], n: number, startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
   multrigrams (sequence: string | string[], n: number, startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
+  /* eslint-enable @typescript-eslint/method-signature-style */
 }
 
 export let NGrams: NGramsFunctions

--- a/lib/natural/ngrams/index.d.ts
+++ b/lib/natural/ngrams/index.d.ts
@@ -22,14 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-declare interface ngramsFunctions {
-  bigrams: (sequence: string | string[], startSymbol?: string, endSymbol?: string) => string[][]
-  // bigrams: (sequence: string[], startSymbol?: string, endSymbol?: string) => string[][]
-  trigrams: (sequence: string | string[], startSymbol?: string, endSymbol?: string) => string[][]
-  // trigrams: (sequence: string[], startSymbol?: string, endSymbol?: string) => string[][]
-  ngrams: (sequence: string | string[], n: number, startSymbol?: string, endSymbol?: string) => string[][]
-  // ngrams: (sequence: string[], n: number, startSymbol?: string, endSymbol?: string) => string[][]
+import Tokenizer from "../tokenizers/tokenizer"
+
+declare interface NGramsStats {
+  ngrams: string[][],
+  frequencies: { [key: string]: number | undefined },
+  Nr: { [key: number]: number | undefined },
+  numberOfNgrams: number,
 }
 
-export declare let NGrams: ngramsFunctions
-export declare let NGramsZH: ngramsFunctions
+declare interface NGramsFunctions {
+  setTokenizer (t: Tokenizer): void
+  ngrams (sequence: string | string[], n: number, startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
+  ngrams (sequence: string | string[], n: number, startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
+  bigrams (sequence: string | string[], startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
+  bigrams (sequence: string | string[], startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
+  trigrams (sequence: string | string[], startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
+  trigrams (sequence: string | string[], startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
+  multrigrams (sequence: string | string[], n: number, startSymbol: string | undefined, endSymbol: string | undefined, stats: true): NGramsStats
+  multrigrams (sequence: string | string[], n: number, startSymbol?: string, endSymbol?: string, stats?: boolean): string[][]
+}
+
+export let NGrams: NGramsFunctions
+export let NGramsZH: NGramsFunctions

--- a/lib/natural/ngrams/index.d.ts
+++ b/lib/natural/ngrams/index.d.ts
@@ -22,13 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Tokenizer from "../tokenizers/tokenizer"
+import Tokenizer from '../tokenizers/tokenizer'
 
 declare interface NGramsStats {
-  ngrams: string[][],
-  frequencies: { [key: string]: number | undefined },
-  Nr: { [key: number]: number | undefined },
-  numberOfNgrams: number,
+  ngrams: string[][]
+  frequencies: { [key: string]: number | undefined }
+  Nr: { [key: number]: number | undefined }
+  numberOfNgrams: number
 }
 
 declare interface NGramsFunctions {

--- a/lib/natural/normalizers/index.d.ts
+++ b/lib/natural/normalizers/index.d.ts
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2022, Dylan R. E. Moonfire <https://github.com/dmoonfire>,
+Emily Marigold Klassen <https://github.com/forivall>,
+Hugo W.L. ter Doest <https://github.com/Hugo-ter-Doest>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+export function normalize (tokens: string | string[]): string[]
+export function normalize_ja (str: string): string
+export function removeDiacritics (str: string): string

--- a/lib/natural/normalizers/index.d.ts
+++ b/lib/natural/normalizers/index.d.ts
@@ -23,5 +23,6 @@ THE SOFTWARE.
 */
 
 export function normalize (tokens: string | string[]): string[]
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function normalize_ja (str: string): string
 export function removeDiacritics (str: string): string

--- a/lib/natural/phonetics/index.d.ts
+++ b/lib/natural/phonetics/index.d.ts
@@ -25,19 +25,19 @@ export interface Phonetic<T> {
   tokenizeAndPhoneticize: (str: string, phoneticsProcessor: Phonetic<T>, keepStops: boolean) => T
 }
 
-declare let Metaphone: Phonetic<string> & {
+export let Metaphone: Phonetic<string> & {
   process: (token: string, maxLength?: number) => string
 }
 
-declare let SoundEx: Phonetic<string> & {
+export let SoundEx: Phonetic<string> & {
   process: (token: string, maxLength?: number) => string
 }
 
-declare let DoubleMetaphone: Phonetic<string[]> & {
+export let DoubleMetaphone: Phonetic<string[]> & {
   process: (token: string, maxLength?: number) => string[]
   isVowel: (c: string) => string | RegExpMatchArray | null
 }
 
-declare let SoundExDM: Phonetic<string> & {
+export let SoundExDM: Phonetic<string> & {
   process: (word: string, codeLength?: number) => string
 }

--- a/lib/natural/phonetics/index.d.ts
+++ b/lib/natural/phonetics/index.d.ts
@@ -20,22 +20,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export interface Phonetic {
+export interface Phonetic<T> {
   compare: (stringA: string, stringB: string) => boolean
+  tokenizeAndPhoneticize: (str: string, phoneticsProcessor: Phonetic<T>, keepStops: boolean) => T
+}
+
+declare let Metaphone: Phonetic<string> & {
   process: (token: string, maxLength?: number) => string
 }
 
-declare let Metaphone: {
-  compare: (stringA: string, stringB: string) => boolean
+declare let SoundEx: Phonetic<string> & {
   process: (token: string, maxLength?: number) => string
 }
 
-declare let SoundEx: {
-  compare: (stringA: string, stringB: string) => boolean
-  process: (token: string, maxLength?: number) => string
-}
-
-declare let DoubleMetaphone: {
-  compare: (stringA: string, stringB: string) => boolean
+declare let DoubleMetaphone: Phonetic<string[]> & {
   process: (token: string, maxLength?: number) => string[]
+  isVowel: (c: string) => string | RegExpMatchArray | null
+}
+
+declare let SoundExDM: Phonetic<string> & {
+  process: (word: string, codeLength?: number) => string
 }

--- a/lib/natural/sentiment/index.d.ts
+++ b/lib/natural/sentiment/index.d.ts
@@ -23,7 +23,18 @@ THE SOFTWARE.
 
 import { Stemmer } from '../stemmers'
 
+export type AfinnLanguageType = 'afinn'
+export type AfinnLanguage = 'English' | 'Spanish' | 'Portuguese'
+
+export type SenticonLanguageType = 'senticon'
+export type SenticonLanguage = 'Spanish' | 'English' | 'Galician' | 'Catalan' | 'Basque'
+
+export type PatternLanguageType = 'pattern'
+export type PatternLanguage = 'Dutch' | 'Italian' | 'English' | 'French'
+
 export declare class SentimentAnalyzer {
-  constructor (language: string, stemmer: Stemmer, vocabulary: string)
+  constructor (language: AfinnLanguage, stemmer: Stemmer, type: AfinnLanguageType)
+  constructor (language: SenticonLanguage, stemmer: Stemmer, type: SenticonLanguageType)
+  constructor (language: PatternLanguage, stemmer: Stemmer, type: PatternLanguageType)
   getSentiment (words: string[]): number
 }

--- a/lib/natural/sentiment/index.d.ts
+++ b/lib/natural/sentiment/index.d.ts
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { Stemmer } from "../stemmers";
+import { Stemmer } from '../stemmers'
 
 export declare class SentimentAnalyzer {
   constructor (language: string, stemmer: Stemmer, vocabulary: string)

--- a/lib/natural/sentiment/index.d.ts
+++ b/lib/natural/sentiment/index.d.ts
@@ -21,6 +21,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import { Stemmer } from "../stemmers";
+
 export declare class SentimentAnalyzer {
   constructor (language: string, stemmer: Stemmer, vocabulary: string)
   getSentiment (words: string[]): number

--- a/lib/natural/stemmers/index.d.ts
+++ b/lib/natural/stemmers/index.d.ts
@@ -20,26 +20,27 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-// Based on the type definitions on definitely typed
-
-export interface Stemmer {
+declare interface Stemmer {
   stem: (token: string) => string
-  tokenizeAndStem: (text: string) => string[]
-  attach: () => void
+  addStopWord: (stopWord: string) => void
+  addStopWords: (moreStopWords: string[]) => void
+  removeStopWord: (stopWord: string) => void
+  removeStopWords: (moreStopWords: string[]) => void
+  tokenizeAndStem: (text: string, keepStops?: boolean) => string[]
 }
 
-declare const CarryStemmerFr: Stemmer
-declare const LancasterStemmer: Stemmer
-declare const PorterStemmer: Stemmer
-declare const PorterStemmerEs: Stemmer
-declare const PorterStemmerFa: Stemmer
-declare const PorterStemmerFr: Stemmer
-declare const PorterStemmerDe: Stemmer
-declare const PorterStemmerIt: Stemmer
-declare const PorterStemmerNl: Stemmer
-declare const PorterStemmerNo: Stemmer
-declare const PorterStemmerPt: Stemmer
-declare const PorterStemmerRu: Stemmer
-declare const PorterStemmerSv: Stemmer
-declare const StemmerId: Stemmer
-declare const StemmerJa: Stemmer
+export let CarryStemmerFr: Stemmer
+export let LancasterStemmer: Stemmer
+export let PorterStemmer: Stemmer
+export let PorterStemmerDe: Stemmer
+export let PorterStemmerEs: Stemmer
+export let PorterStemmerFa: Stemmer
+export let PorterStemmerFr: Stemmer
+export let PorterStemmerIt: Stemmer
+export let PorterStemmerNl: Stemmer
+export let PorterStemmerNo: Stemmer
+export let PorterStemmerPt: Stemmer
+export let PorterStemmerRu: Stemmer
+export let PorterStemmerSv: Stemmer
+export let StemmerId: Stemmer
+export let StemmerJa: Stemmer

--- a/lib/natural/tfidf/index.d.ts
+++ b/lib/natural/tfidf/index.d.ts
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Tokenizer from "../tokenizers/tokenizer"
+import Tokenizer from '../tokenizers/tokenizer'
 
 declare type TfIdfCallback = (i: number, measure: number, key?: string) => void
 

--- a/lib/natural/tfidf/index.d.ts
+++ b/lib/natural/tfidf/index.d.ts
@@ -23,20 +23,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export type TfIdfCallback = (i: number, measure: number) => void
+import Tokenizer from "../tokenizers/tokenizer"
 
-export interface TfIdfTerm {
+declare type TfIdfCallback = (i: number, measure: number, key?: string) => void
+
+declare interface TfIdfTerm {
   term: string
+  tf: number
+  idf: number
   tfidf: number
 }
 
-export declare class TfIdf {
-  constructor (deserialized?: any)
-  addDocument (document: string, key?: string, restoreCache?: boolean): void
-  addDocument (document: string[], key?: string, restoreCache?: boolean): void
+declare type TfIdfDocument = { __key: string | undefined } | { [key: string]: number | undefined }
+
+export class TfIdf {
+  documents: TfIdfDocument | undefined
+  _idfCache: { [key: string]: number } | undefined
+
+  constructor (deserialized?: { documents: TfIdfDocument[] })
+  idf (term: string, force?: boolean): number
+  addDocument (document: string | string[], key?: string, restoreCache?: boolean): void
   addFileSync (path: string, encoding?: string, key?: string, restoreCache?: boolean): void
-  tfidf (terms: string, d: number): void
-  tfidfs (terms: string, callback: TfIdfCallback): void
-  tfidfs (terms: string[], callback: TfIdfCallback): void
+  tfidf (terms: string | string[], d: number): number
+  tfidfs (terms: string | string[], callback?: TfIdfCallback): number[]
   listTerms (d: number): TfIdfTerm[]
+  setTokenizer (t: Tokenizer): void
+  setStopwords (customStopwords: string[]): boolean
+  static tf (term: string, document: TfIdfDocument): number
 }

--- a/lib/natural/tokenizers/index.d.ts
+++ b/lib/natural/tokenizers/index.d.ts
@@ -20,83 +20,117 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-// Based on type definitions on Definitely Typed
+declare class Tokenizer {
+  trim: (array: string[]) => string[]
+}
 
-export interface Tokenizer {
-  tokenize: (text: string) => string[]
-}
-export declare class WordTokenizer implements Tokenizer {
+export class AggressiveTokenizerNl extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class TreebankWordTokenizer implements Tokenizer {
+
+export class AggressiveTokenizerFa extends Tokenizer {
+  clearEmptyString (array: string[]): string[]
+  clearText (text: string): string
   tokenize (text: string): string[]
 }
-export interface RegexTokenizerOptions {
-  pattern?: RegExp | undefined
-  discardEmpty?: boolean | undefined
-}
-export declare class RegexpTokenizer implements Tokenizer {
-  constructor (options: RegexTokenizerOptions)
+
+export class AggressiveTokenizerFr extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class OrthographyTokenizer implements Tokenizer {
-  constructor (options: RegexTokenizerOptions & { language: string })
+
+export class AggressiveTokenizerDe extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class WordPunctTokenizer implements Tokenizer {
+
+export class AggressiveTokenizerRu extends Tokenizer {
+  withoutEmpty (array: string[]): string[]
+  clearText (text: string): string
   tokenize (text: string): string[]
 }
-export declare class SentenceTokenizer implements Tokenizer {
+
+export class AggressiveTokenizerEs extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class SentenceTokenizerNew implements Tokenizer {
+
+export class AggressiveTokenizerIt extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class CaseTokenizer implements Tokenizer {
-  tokenize (text: string, preserveApostrophy?: boolean): string[]
-}
-export declare class AggressiveTokenizer implements Tokenizer {
+
+export class AggressiveTokenizerPl extends Tokenizer {
+  withoutEmpty (array: string[]): string[]
+  clearText (text: string): string
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerEs implements Tokenizer {
+
+export class AggressiveTokenizerPt extends Tokenizer {
+  withoutEmpty (array: string[]): string[]
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerFa implements Tokenizer {
+
+export class AggressiveTokenizerNo extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerFr implements Tokenizer {
+
+export class AggressiveTokenizerSv extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerDe implements Tokenizer {
+
+export class AggressiveTokenizerVi extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerId implements Tokenizer {
+
+export class AggressiveTokenizerId extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerIt implements Tokenizer {
+
+export class AggressiveTokenizer extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerNl implements Tokenizer {
+
+export class CaseTokenizer extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerNo implements Tokenizer {
+
+declare interface RegexTokenizerOptions {
+  pattern?: RegExp
+  discardEmpty?: boolean
+  gaps?: boolean
+}
+
+export class RegexpTokenizer extends Tokenizer {
+  constructor (opts?: RegexTokenizerOptions)
+  tokenize (text: string): string[] | null
+}
+
+declare interface OrthographyTokenizerOptions extends RegexTokenizerOptions {
+  language: string
+}
+
+export class OrthographyTokenizer extends RegexpTokenizer {
+  constructor (options: OrthographyTokenizerOptions)
+}
+
+export class WordTokenizer extends RegexpTokenizer {
+  constructor (options?: RegexTokenizerOptions)
+}
+
+export class WordPunctTokenizer extends RegexpTokenizer {
+  constructor (options?: RegexTokenizerOptions)
+}
+
+export class TreebankWordTokenizer extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerPl implements Tokenizer {
+
+export class TokenizerJa extends Tokenizer {
+  removePuncTokens (tokens: string[]): string[]
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerPt implements Tokenizer {
+
+export class SentenceTokenizer extends Tokenizer {
   tokenize (text: string): string[]
 }
-export declare class AggressiveTokenizerRu implements Tokenizer {
-  tokenize (text: string): string[]
-}
-export declare class AggressiveTokenizerSv implements Tokenizer {
-  tokenize (text: string): string[]
-}
-export declare class AggressiveTokenizerVi implements Tokenizer {
-  tokenize (text: string): string[]
-}
-export declare class TokenizerJa implements Tokenizer {
+
+export class SentenceTokenizerNew extends Tokenizer {
   tokenize (text: string): string[]
 }

--- a/lib/natural/tokenizers/index.d.ts
+++ b/lib/natural/tokenizers/index.d.ts
@@ -37,7 +37,7 @@ export interface RegexTokenizerOptions {
 }
 export declare class RegexpTokenizer implements Tokenizer {
   constructor (options: RegexTokenizerOptions)
-  tokenize (text: string): string[];
+  tokenize (text: string): string[]
 }
 export declare class OrthographyTokenizer implements Tokenizer {
   constructor (options: RegexTokenizerOptions & { language: string })

--- a/lib/natural/transliterators/index.d.ts
+++ b/lib/natural/transliterators/index.d.ts
@@ -21,7 +21,4 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-// First define a function type for transliterators ...
-export declare type TransliteratorFunction = (s: string) => string
-// and then export the Japanese transliterator as a function of that type
-export declare let TransliterateJa: TransliteratorFunction
+export let TransliterateJa: (s: string) => string

--- a/lib/natural/trie/index.d.ts
+++ b/lib/natural/trie/index.d.ts
@@ -22,12 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare class Trie {
+export class Trie {
   constructor (caseSensitive?: boolean)
-  addString (text: string): boolean
-  addStrings (strings: string[]): void
-  contains (token: string): boolean
-  findPrefix (text: string): string[]
-  findMatchesOnPath (text: string): string[]
-  keysWithPrefix (text: string): string[]
+  addString (string: string): boolean
+  addStrings (list: string[]): void
+  contains (string: string): boolean
+  findPrefix (search: string): string[]
+  findMatchesOnPath (search: string): string[]
+  keysWithPrefix (prefix: string): string[]
+  getSize (): number
 }

--- a/lib/natural/util/index.d.ts
+++ b/lib/natural/util/index.d.ts
@@ -23,21 +23,49 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export declare class EdgeWeightedDigraph {
-  add (start: number, end: number, weight: number): void
-  v (): number
-  e (): number
+export let stopwords: string[]
+
+declare class Bag<T> {
+  add (element: T): Bag<T>
+  isEmpty (): boolean
+  contains (item: T): boolean
+  unpack (): T[]
 }
 
-export declare class ShortestPathTree {
-  constructor (diagraph: EdgeWeightedDigraph, startVertex: number)
+declare class DirectedEdge {
+  constructor (start: number, end: number, weight: number)
+  weight (): number
+  from (): number
+  to (): number
+  toString (): string
+}
+
+export class EdgeWeightedDigraph {
+  edgesNum: number
+  adj: Bag<DirectedEdge>[]
+
+  add (start: number, end: number, weight: number): void
+  addEdge (e: DirectedEdge): void
+  v (): number
+  e (): number
+  getAdj (v: number): DirectedEdge[]
+  edges (): DirectedEdge[]
+  toString (): string
+}
+
+export class ShortestPathTree {
+  constructor (diagraph: EdgeWeightedDigraph, start: number)
+  relaxEdge (e: DirectedEdge): void
+  relaxVertex (digraph: EdgeWeightedDigraph, vertex: number, tree: ShortestPathTree): void
   getDistTo (vertex: number): number
   hasPathTo (vertex: number): boolean
   pathTo (vertex: number): number[]
 }
 
-export declare class LongestPathTree {
-  constructor (diagraph: EdgeWeightedDigraph, startVertex: number)
+export class LongestPathTree {
+  constructor (diagraph: EdgeWeightedDigraph, start: number)
+  relaxEdge (e: DirectedEdge): void
+  relaxVertex (digraph: EdgeWeightedDigraph, vertex: number, tree: LongestPathTree): void
   getDistTo (vertex: number): number
   hasPathTo (vertex: number): boolean
   pathTo (vertex: number): number[]

--- a/lib/natural/util/index.d.ts
+++ b/lib/natural/util/index.d.ts
@@ -29,7 +29,7 @@ declare class Bag<T> {
   add (element: T): Bag<T>
   isEmpty (): boolean
   contains (item: T): boolean
-  unpack (): Array<T>
+  unpack (): T[]
 }
 
 declare class DirectedEdge {
@@ -42,7 +42,7 @@ declare class DirectedEdge {
 
 export class EdgeWeightedDigraph {
   edgesNum: number
-  adj: Bag<DirectedEdge>[]
+  adj: Array<Bag<DirectedEdge>>
 
   add (start: number, end: number, weight: number): void
   addEdge (e: DirectedEdge): void

--- a/lib/natural/util/index.d.ts
+++ b/lib/natural/util/index.d.ts
@@ -29,7 +29,7 @@ declare class Bag<T> {
   add (element: T): Bag<T>
   isEmpty (): boolean
   contains (item: T): boolean
-  unpack (): T[]
+  unpack (): Array<T>
 }
 
 declare class DirectedEdge {

--- a/lib/natural/wordnet/index.d.ts
+++ b/lib/natural/wordnet/index.d.ts
@@ -24,9 +24,9 @@ THE SOFTWARE.
 */
 
 declare interface DataPtr {
-  pointerSymbol: string,
-  synsetOffset: number,
-  pos: string,
+  pointerSymbol: string
+  synsetOffset: number
+  pos: string
   sourceTarget: string
 }
 

--- a/lib/natural/wordnet/index.d.ts
+++ b/lib/natural/wordnet/index.d.ts
@@ -23,20 +23,76 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export interface WordNetLookupResults {
-  synsetOffset: number
-  pos: string
-  lemma: string
-  synonyms: string[]
-  gloss: string
+declare interface DataPtr {
+  pointerSymbol: string,
+  synsetOffset: number,
+  pos: string,
+  sourceTarget: string
 }
 
-export type WordNetLookupCallback = (results: WordNetLookupResults[]) => void
+declare interface DataRecord {
+  synsetOffset: number
+  lexFilenum: number
+  pos: string
+  wCnt: number
+  lemma: string
+  synonyms: string[]
+  lexId: string
+  ptrs: DataPtr[]
+  gloss: string
+  def: string
+  exp: string[]
+}
 
-export type WordNetGetCallback = (results: WordNetLookupResults) => void
+declare type DataRecordCallback = (results: DataRecord) => void
+declare type DataRecordsCallback = (results: DataRecord[]) => void
 
-export declare class WordNet {
-  constructor (filename?: string)
-  lookup (word: string, callback: WordNetLookupCallback): void
-  get (synsetOffset: number, pos: string, callback: WordNetGetCallback): void
+declare class DataFile {
+  constructor (dataDir: string, name: string)
+  get (location: number, callback: DataRecordCallback): void
+}
+
+declare interface IndexRecord {
+  lemma: string
+  pos: string
+  ptrSymbol: string[]
+  senseCnt: number
+  tagsenseCnt: number
+  synsetOffset: number[]
+}
+
+declare type IndexRecordCallback = (results: IndexRecord) => void
+
+declare interface IndexFind {
+  status: string
+  key: string
+  line: string
+  tokens: string[]
+}
+
+declare type IndexFindCallback = (results: IndexFind) => void
+
+declare class IndexFile {
+  constructor (dataDir: string, name: string)
+  lookup (word: string, callback: IndexRecordCallback): void
+  lookupFromFile (word: string, callback: IndexRecordCallback): void
+  find (word: string, callback: IndexFindCallback): void
+}
+
+declare interface WordNetLookupFile {
+  index: IndexFile
+  data: DataFile
+}
+
+export class WordNet {
+  constructor (dataDir?: string)
+  get (synsetOffset: number, pos: string, callback: DataRecordCallback): void
+  lookup (word: string, callback: DataRecordsCallback): void
+  lookupFromFiles (files: WordNetLookupFile[], results: DataRecord[], word: string, callback: DataRecordsCallback): void
+  pushResults (data: DataFile, results: DataRecord[], offsets: number[], callback: DataRecordsCallback): void
+  loadResultSynonyms (synonyms: DataRecord[], results: DataRecord[], callback: DataRecordsCallback): void
+  loadSynonyms (synonyms: DataRecord[], results: DataRecord[], ptrs: DataPtr[], callback: DataRecordsCallback): void
+  lookupSynonyms (word: string, callback: DataRecordsCallback): void
+  getSynonyms (record: DataRecord, callback: DataRecordsCallback): void
+  getDataFile (pos: string): DataFile
 }

--- a/spec/classifiers_test.ts
+++ b/spec/classifiers_test.ts
@@ -21,15 +21,17 @@ classifier.events.on('trainedWithDocument', function (obj: any) {
   console.log(obj)
 })
 
-classifier.save('classifier.json', function (err: any, classifier: BayesClassifier) {
+classifier.save('classifier.json', function (err: NodeJS.ErrnoException, classifier?: BayesClassifier) {
   if (err !== undefined) {
     console.log(err)
   } else {
     // the classifier is saved to the classifier.json file!
     console.log('The classifier is saved to the classifier.json file!')
-    BayesClassifier.load('classifier.json', null, function (err: any, classifier: BayesClassifier) {
+    BayesClassifier.load('classifier.json', null, function (err: NodeJS.ErrnoException, classifier?: BayesClassifier) {
       if (err !== undefined) {
         console.log(err)
+      } else if (classifier == null) { // coercion catches null or undefined
+        console.error('Classifier is missing from callback arguments')
       } else {
         console.log('Classify long SUNW' + classifier.classify('long SUNW'))
         console.log('Classify short SUNW' + classifier.classify('short SUNW'))

--- a/spec/classifiers_test.ts
+++ b/spec/classifiers_test.ts
@@ -21,13 +21,13 @@ classifier.events.on('trainedWithDocument', function (obj: any) {
   console.log(obj)
 })
 
-classifier.save('classifier.json', function (err: NodeJS.ErrnoException, classifier?: BayesClassifier) {
+classifier.save('classifier.json', function (err: NodeJS.ErrnoException | null, classifier?: BayesClassifier) {
   if (err !== undefined) {
     console.log(err)
   } else {
     // the classifier is saved to the classifier.json file!
     console.log('The classifier is saved to the classifier.json file!')
-    BayesClassifier.load('classifier.json', null, function (err: NodeJS.ErrnoException, classifier?: BayesClassifier) {
+    BayesClassifier.load('classifier.json', null, function (err: NodeJS.ErrnoException | null, classifier?: BayesClassifier) {
       if (err !== undefined) {
         console.log(err)
       } else if (classifier == null) { // coercion catches null or undefined

--- a/spec/classifiers_test.ts
+++ b/spec/classifiers_test.ts
@@ -1,4 +1,4 @@
-import { BayesClassifier } from '../lib/natural/classifiers'
+import { BayesClassifier } from '../lib/natural'
 
 let classifier = new BayesClassifier()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "strict": true
   },
   "include": [
     "lib/natural/**/*",


### PR DESCRIPTION
Update all TS declarations based on current module exports.

Convention:
Reserve export keyword for members of a module that are actually
exported in the corresponding index.js. For everything else, use declare
to make the type/instance available.

Example:
index.js contains: exports.SomeClass = require('...')
index.d.ts should then only have one exported item: export SomeClass ...
and any types needed to support SomeClass use declare.

TODO for maintainer(s) of natural: Lots of class properties and methods
are added that may only be intended for internal use. These can either be
removed or be prefixed with keyword `private`.