### PR TITLE
Fix Tokenizer imports in TS declarations

### DIFF
--- a/lib/natural/ngrams/index.d.ts
+++ b/lib/natural/ngrams/index.d.ts
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Tokenizer from '../tokenizers/tokenizer'
+import { Tokenizer } from '../tokenizers'
 
 declare interface NGramsStats {
   ngrams: string[][]

--- a/lib/natural/tfidf/index.d.ts
+++ b/lib/natural/tfidf/index.d.ts
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Tokenizer from '../tokenizers/tokenizer'
+import { Tokenizer } from '../tokenizers'
 
 declare type TfIdfCallback = (i: number, measure: number, key?: string) => void
 


### PR DESCRIPTION
The Tokenizer type definition should come from tokenizer/index.d.ts, not from the tokenizer.js file.

Fixes #684