### PR TITLE
Allow for extension of lexicon

### DIFF
--- a/lib/natural/brill_pos_tagger/lib/Lexicon.js
+++ b/lib/natural/brill_pos_tagger/lib/Lexicon.js
@@ -24,18 +24,20 @@ const dutchLexicon = require('../data/Dutch/brill_Lexicon.json')
 const DEBUG = false
 
 // Constructor creates a Lexicon for language
-function Lexicon (language, defaultCategory, defaultCategoryCapitalised) {
-  switch (language) {
-    case 'EN':
-      this.lexicon = englishLexicon
-      break
-    case 'DU':
-      this.lexicon = dutchLexicon
-      break
-    default:
-      this.lexicon = dutchLexicon
-      break
-  }
+function Lexicon (language, defaultCategory, defaultCategoryCapitalised, extendedLexicon) {
+  const lexicon = (() => {
+    switch (language) {
+      case 'EN':
+        return englishLexicon
+      case 'DU':
+        return dutchLexicon
+      default:
+        return dutchLexicon
+    }
+  })()
+
+  this.lexicon = Object.assign(lexicon, extendedLexicon || {})
+
   if (defaultCategory) {
     this.defaultCategory = defaultCategory
     if (defaultCategoryCapitalised) {


### PR DESCRIPTION
## Context
I was working with the tagger API, and I realized that many "tech" words aren't tagged properly. As a work-around, I'm currently doing this, but thought it would be useful to have a way to do so within the API:
```tsx
import extendedLexicon from './lexicon.json'

const lexicon = new Lexicon(language, TAGS.DEFAULT)

lexicon.lexicon = {
  ...lexicon.lexicon,
  ...extendedLexicon,
}
```


## Summary
Add 4th parameter to allow for the extension of lexicons to prevent breaking previous versions.