### PR TITLE
Fix module path

### DIFF
--- a/examples/stemming/stem_corpus.js
+++ b/examples/stemming/stem_corpus.js
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 'use strict'
 
-const natural = require('lib/natural')
+const natural = require('natural')
 const stemmer = natural.PorterStemmer
 
 console.log(stemmer.tokenizeAndStem('i stemmed words.'))


### PR DESCRIPTION
The initial path `lib/natural` was causing a 'MODULE_NOT_FOUND' error, as it did not correctly point to the installed 'natural' module in 'node_modules'. By changing the path to just `natural`, Node.js can correctly locate and load the module as expected.