### PR TITLE
Docs - Fix reference error in example regarding tokenizers in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ means fork away!
 
 Each part of the library has its own `index.js` file. You only have to include the module you are actually using. For instance, if you are using one of the tokenizers:
 ```javascript
-const tokenenizers = require('natural/lib/natural/tokenizers')
+const tokenizers = require('natural/lib/natural/tokenizers')
 const tokenizer = new tokenizers.SentenceTokenizer()
 ```
 


### PR DESCRIPTION
Running the following example located at [installation.md](https://github.com/NaturalNode/natural/blob/gh-pages/docs/installation.md): 
```js
const tokenenizers = require('natural/lib/natural/tokenizers')
const tokenizer = new tokenizers.SentenceTokenizer()
```
Throws `Uncaught ReferenceError: tokenizers is not defined`. 
This pull request fix the reference to  `const tokenizers = require('natural/lib/natural/tokenizers')`

Issue mentioned in #719 