### PR TITLE
Fixed the BayesClassifier.load error

### DIFF
--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -43,7 +43,7 @@ class BayesClassifier extends Classifier {
     return classifier
   }
 
-  load (filename, stemmer, callback) {
+  static load (filename, stemmer, callback) {
     Classifier.load(filename, function (err, classifier) {
       if (err) {
         return callback(err)

--- a/lib/natural/classifiers/bayes_classifier.js
+++ b/lib/natural/classifiers/bayes_classifier.js
@@ -48,7 +48,7 @@ class BayesClassifier extends Classifier {
       if (err) {
         return callback(err)
       } else {
-        callback(err, this.restore(classifier, stemmer))
+        callback(err, BayesClassifier.restore(classifier, stemmer))
       }
     })
   }


### PR DESCRIPTION
I fixed the error where the BayesClassifier.load() was not returning anything. By adding the static keyword and changing "this.restore" to "BayesClassifier.restore", the load function works properly and the user can classify data with a pre-saved classifier.