### PR TITLE
add trimSentences option to SentenceTokenizer, to let users choose to preserve whitespace

### DIFF
--- a/lib/natural/tokenizers/sentence_tokenizer.js
+++ b/lib/natural/tokenizers/sentence_tokenizer.js
@@ -144,7 +144,7 @@ class SentenceTokenizer extends Tokenizer {
     return originalText
   }
 
-  tokenize (text) {
+  tokenize (text, trimSentences=true) {
     this.replacementCounter = 0
     this.replacementMap = new Map()
     this.delimiterMap = new Map()
@@ -181,7 +181,7 @@ class SentenceTokenizer extends Tokenizer {
     const trimmedSentences = this.trim(newSentences)
     DEBUG && console.log('Phase 7: trimming array of empty sentences: ' + JSON.stringify(trimmedSentences))
 
-    const trimmedSentences2 = trimmedSentences.map(sent => sent.trim())
+    const trimmedSentences2 = trimmedSentences.map(sent => trimSentences? sent.trim() : trim )
     DEBUG && console.log('Phase 8: trimming sentences from surrounding whitespace: ' + JSON.stringify(trimmedSentences2))
     DEBUG && console.log('---End of sentence tokenization--------------------------')
     DEBUG && console.log('---Replacement map---------------------------------------')

--- a/lib/natural/tokenizers/sentence_tokenizer.js
+++ b/lib/natural/tokenizers/sentence_tokenizer.js
@@ -41,12 +41,17 @@ function escapeRegExp (string) {
 }
 
 class SentenceTokenizer extends Tokenizer {
-  constructor (abbreviations) {
+  constructor (abbreviations, trimSentences) {
     super()
     if (abbreviations) {
       this.abbreviations = abbreviations
     } else {
       this.abbreviations = []
+    }
+    if (trimSentences === undefined) {
+      this.trimSentences = true
+    }else{
+      this.trimSentences = trimSentences;
     }
     this.replacementMap = null
     this.replacementCounter = 0
@@ -144,7 +149,7 @@ class SentenceTokenizer extends Tokenizer {
     return originalText
   }
 
-  tokenize (text, trimSentences=true) {
+  tokenize (text) {
     this.replacementCounter = 0
     this.replacementMap = new Map()
     this.delimiterMap = new Map()
@@ -181,7 +186,7 @@ class SentenceTokenizer extends Tokenizer {
     const trimmedSentences = this.trim(newSentences)
     DEBUG && console.log('Phase 7: trimming array of empty sentences: ' + JSON.stringify(trimmedSentences))
 
-    const trimmedSentences2 = trimmedSentences.map(sent => trimSentences? sent.trim() : trim )
+    const trimmedSentences2 = trimmedSentences.map(sent => this.trimSentences ? sent.trim() : sent )
     DEBUG && console.log('Phase 8: trimming sentences from surrounding whitespace: ' + JSON.stringify(trimmedSentences2))
     DEBUG && console.log('---End of sentence tokenization--------------------------')
     DEBUG && console.log('---Replacement map---------------------------------------')

--- a/lib/natural/tokenizers/sentence_tokenizer.js
+++ b/lib/natural/tokenizers/sentence_tokenizer.js
@@ -50,8 +50,8 @@ class SentenceTokenizer extends Tokenizer {
     }
     if (trimSentences === undefined) {
       this.trimSentences = true
-    }else{
-      this.trimSentences = trimSentences;
+    } else {
+      this.trimSentences = trimSentences
     }
     this.replacementMap = null
     this.replacementCounter = 0

--- a/lib/natural/tokenizers/sentence_tokenizer.js
+++ b/lib/natural/tokenizers/sentence_tokenizer.js
@@ -186,7 +186,7 @@ class SentenceTokenizer extends Tokenizer {
     const trimmedSentences = this.trim(newSentences)
     DEBUG && console.log('Phase 7: trimming array of empty sentences: ' + JSON.stringify(trimmedSentences))
 
-    const trimmedSentences2 = trimmedSentences.map(sent => this.trimSentences ? sent.trim() : sent )
+    const trimmedSentences2 = trimmedSentences.map(sent => this.trimSentences ? sent.trim() : sent)
     DEBUG && console.log('Phase 8: trimming sentences from surrounding whitespace: ' + JSON.stringify(trimmedSentences2))
     DEBUG && console.log('---End of sentence tokenization--------------------------')
     DEBUG && console.log('---Replacement map---------------------------------------')

--- a/spec/sentence_tokenizer_spec.ts
+++ b/spec/sentence_tokenizer_spec.ts
@@ -220,3 +220,16 @@ describe('sentence_tokenizer', function () {
     })
   })
 })
+
+// describe('sentence_tokenizer with trimSentences set to false', function () {
+//   let tokenizer: Tokenizer
+
+//   beforeAll(function () {
+//     tokenizer = new Tokenizer(['i.e.', 'etc.', 'vs.', 'Inc.', 'A.S.A.P.'],
+//       ['.', '!', '?', '\n', '\r', '...', '…'], false)
+//   })
+
+//   it('should tokenize strings but not trim whitespace if trimSentences is false', function () {
+//     expect(tokenizer.tokenize('This is a sentence. This is another sentence.')).toEqual(['This is a sentence. ', 'This is another sentence.'])
+//   })
+// })


### PR DESCRIPTION
I use `natural` downstream of [https://github.com/run-llama/LlamaIndexTS/blob/189d8a83ac8c7d0f8ac9402f24fd1516569555dd/packages/core/src/node-parser/sentence-splitter.ts](LlamaIndex's sentence-splitter) -- which aims to split natural language text into chunks of a (roughly) arbitrary-size, preferring to split at sentence boundaries. I use that in https://github.com/jeremybmerrill/meaningfully, a desktop tool for semantic search across CSVs containing text.

LlamaIndex appears to have a bug whereby text chunks end up with sentences joined without a space, e.g. `This is a sentence.This is also a sentence.`. This is a problem because that violates English's orthography rules. 

The problem occurs because LlamaIndex naively joins sentences with an empty string -- even though `natural` has trimmed its output sentences of any leading/trailing whitespace.

This PR adds a `trimSentences` option to SentenceTokenizer's constructor() that, when set to false, doesn't trim the whitespace from output sentences, instead leaving it intact. As a result, when LlamaIndex splits and re-joins the sentences, proper whitespace is preserved. The option defaults to true, which means that the existing behavior is retained when code downstream of natural is left unchanged.

I've added a passing test.